### PR TITLE
get version via the endpoint, rework host config, add some skeleton w…

### DIFF
--- a/commands/apitest.go
+++ b/commands/apitest.go
@@ -18,10 +18,11 @@ type APIStatus struct {
 // TestAPI checks the "../<testpath>" endpoint and returns the status returned.
 func TestAPI() error { // This should be suppressed when not directly called unless debug is set
 	status := &APIStatus{}
-	resp, err := client.New().Get(testpath).ReceiveSuccess(status)
+	resp, err := client.NewUnversioned().Get(testpath).ReceiveSuccess(status)
 	if err != nil {
 		return err
 	}
+
 	if resp.StatusCode != http.StatusOK {
 		return err
 	}

--- a/commands/lights.go
+++ b/commands/lights.go
@@ -17,7 +17,6 @@ type LightsDetails struct {
 	Color      int16  `json:"color"`
 }
 
-
 // LightsResult contains the fields returned and a result object from a lights query
 type LightsResult struct {
 	utils.Result

--- a/commands/temperature.go
+++ b/commands/temperature.go
@@ -18,7 +18,6 @@ type TempDetails struct {
 	TemperatureC float64  `json:"temperature_c"`
 }
 
-
 // TempResult contains the detailed fields and result object from a temperature query
 type TempResult struct {
 	utils.Result

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,0 +1,15 @@
+package flags
+
+import (
+	"github.com/urfave/cli"
+)
+
+var debugFlag = cli.BoolFlag{
+	Name:  "debug, d",
+	Usage: "enable debug mode",
+}
+
+
+var Flags = []cli.Flag{
+	debugFlag,
+}

--- a/scheme/info.go
+++ b/scheme/info.go
@@ -1,0 +1,43 @@
+package scheme
+
+type RackInfo struct {
+	Rack   string   `json:"rack"`
+	Boards []string `json:"boards"`
+}
+
+type BoardInfo struct {
+	Board    string            `json:"board"`
+	Location map[string]string `json:"location"`
+	Devices  []string          `json:"devices"`
+}
+
+type DeviceInfo struct {
+	Timestamp    string            `json:"timestamp"`
+	UID          string            `json:"uid"`
+	Type         string            `json:"type"`
+	Model        string            `json:"model"`
+	Manufacturer string            `json:"manufacturer"`
+	Protocol     string            `json:"protocol"`
+	Info         string            `json:"info"`
+	Comment      string            `json:"comment"`
+	Location     map[string]string `json:"location"`
+	Output       []DeviceOutput    `json:"output"`
+}
+
+type DeviceOutput struct {
+	Type      string      `json:"type"`
+	DataType  string      `json:"data_type"`
+	Precision int         `json:"precision"`
+	Unit      OutputUnit  `json:"unit"`
+	Range     OutputRange `json:"range"`
+}
+
+type OutputUnit struct {
+	Name   string `json:"name"`
+	Symbol string `json:"symbol"`
+}
+
+type OutputRange struct {
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
+}

--- a/scheme/read.go
+++ b/scheme/read.go
@@ -1,0 +1,20 @@
+package scheme
+
+// Read
+type Read struct {
+	Type string          `json:"type"`
+	Data map[string]Data `json:"data"`
+}
+
+// Data
+type Data struct {
+	Value     interface{} `json:"value"`
+	Timestamp string      `json:"timestamp"`
+	Unit      Unit        `json:"unit"`
+}
+
+// Unit
+type Unit struct {
+	Name   string `json:"name"`
+	Symbol string `json:"symbol"`
+}

--- a/scheme/scan.go
+++ b/scheme/scan.go
@@ -1,0 +1,25 @@
+package scheme
+
+// Scan
+type Scan struct {
+	Racks []Rack `json:"racks"`
+}
+
+// Rack
+type Rack struct {
+	Id     string  `json:"id"`
+	Boards []Board `json:"boards"`
+}
+
+// Board
+type Board struct {
+	Id      string   `json:"id"`
+	Devices []Device `json:"devices"`
+}
+
+// Device
+type Device struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+	Info string `json:"info"`
+}

--- a/scheme/status.go
+++ b/scheme/status.go
@@ -1,0 +1,7 @@
+package scheme
+
+// TestStatus
+type TestStatus struct {
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
+}

--- a/scheme/transaction.go
+++ b/scheme/transaction.go
@@ -1,0 +1,11 @@
+package scheme
+
+// Transaction
+type Transaction struct {
+	Id      string       `json:"id"`
+	Context WriteContext `json:"context"`
+	State   string       `json:"state"`
+	Created string       `json:"created"`
+	Updated string       `json:"updated"`
+	Message string       `json:"message"`
+}

--- a/scheme/version.go
+++ b/scheme/version.go
@@ -1,0 +1,7 @@
+package scheme
+
+// Version
+type Version struct {
+	Version    string `json:"version"`
+	APIVersion string `json:"api_version"`
+}

--- a/scheme/write.go
+++ b/scheme/write.go
@@ -1,0 +1,18 @@
+package scheme
+
+// Write
+type Write struct {
+	Transactions []WriteTransaction
+}
+
+// WriteTransaction
+type WriteTransaction struct {
+	Context     WriteContext `json:"context"`
+	Transaction string       `json:"transaction"`
+}
+
+// WriteContext
+type WriteContext struct {
+	Action string   `json:"action"`
+	Raw    []string `json:"raw"`
+}

--- a/synse.go
+++ b/synse.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/config"
 	"github.com/vapor-ware/synse-cli/commands"
-	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/flags"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -23,11 +23,14 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "synse"
-	app.Usage = "Synse Shell"
+	app.Usage = "Synse CLI"
 	app.Version = "0.1.0"
-	app.Authors = []cli.Author{{Name: "Tim Fall", Email: "tim@vapor.io"},
-		{Name: "Thomas Rampelberg", Email: "thomasr@vapor.io"}}
+	app.Authors = []cli.Author{
+		{Name: "Tim Fall", Email: "tim@vapor.io"},
+		{Name: "Thomas Rampelberg", Email: "thomasr@vapor.io"},
+	}
 
+	app.Flags = flags.Flags
 	app.Commands = commands.Commands
 	//app.CommandNotFound = commands.CommandNotFound
 	app.EnableBashCompletion = true
@@ -39,36 +42,16 @@ func main() {
 		}
 
 		// Construct the config for this session.
-		err := utils.ConstructConfig(c)
+		err := config.ConstructConfig(c)
 		if err != nil {
 			fmt.Println(err)
 		}
 
-		if utils.Config.Debug {
+		if config.Config.Debug {
 			log.SetLevel(log.DebugLevel)
 		}
 
-		// Pass configuration results to the appropriate functions.
-		client.Config(utils.Config.SynseHost)
-
 		return nil
-	}
-
-	app.Flags = []cli.Flag{
-		cli.BoolFlag{
-			Name:  "debug, d",
-			Usage: "Enable debug mode",
-		},
-		cli.StringFlag{
-			EnvVar: "SYNSE_CONFIG_FILE",
-			Name:   "config, c",
-			Usage:  "Path to config `file`",
-		},
-		cli.StringFlag{
-			EnvVar: "SYNSE_HOST",
-			Name:   "synse-host, host",
-			Usage:  "Address of `Synse Host`",
-		},
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
…ork, organization and cleanup


This PR does a bunch of stuff. 
* Most of it is cleaning/reorganizing for some future work. 
* Also started to add structs for the 2.0 JSON responses  into the `scheme` directory. 
* Redid how hosts are tracked so we are capable of configuring more than one (see #59 )
* Instead of hardcoding version 1.4, we get the version from the `/synse/version` endpoint

Still a lot of work to do around these changes, but its a start. Opening a PR here more as a checkpoint to keep 2.0 work manageable to review.

*Discalaimer*: These changes will break tests, but since we are just merging into the 2.0 branch, it will not affect master.