### PR TITLE
add the functionality for the 'hosts' subcommands

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -75,8 +75,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-cli/commands/hosts"
+	"github.com/vapor-ware/synse-cli/utils"
 
 	"github.com/urfave/cli"
 )

--- a/commands/hosts/active.go
+++ b/commands/hosts/active.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/config"
 )
 
 var hostsActiveCommand = cli.Command{
@@ -14,6 +15,10 @@ var hostsActiveCommand = cli.Command{
 }
 
 func cmdActive(c *cli.Context) error {
-	fmt.Println("hosts active")
+	if config.Config.ActiveHost == nil {
+		return cli.NewExitError("no active host set", 1)
+	}
+	fmt.Printf("Name:    %s\n", config.Config.ActiveHost.Name)
+	fmt.Printf("Address: %s\n", config.Config.ActiveHost.Address)
 	return nil
 }

--- a/commands/hosts/active.go
+++ b/commands/hosts/active.go
@@ -8,10 +8,9 @@ import (
 )
 
 var hostsActiveCommand = cli.Command{
-	Name: "active",
-	Usage: "print the active Synse Server instance",
+	Name:   "active",
+	Usage:  "print the active Synse Server instance",
 	Action: cmdActive,
-
 }
 
 func cmdActive(c *cli.Context) error {

--- a/commands/hosts/add.go
+++ b/commands/hosts/add.go
@@ -6,10 +6,9 @@ import (
 )
 
 var hostAddCommand = cli.Command{
-	Name: "add",
-	Usage: "add a Synse Server instance to the tracked hosts",
+	Name:   "add",
+	Usage:  "add a Synse Server instance to the tracked hosts",
 	Action: cmfAdd,
-
 }
 
 func cmfAdd(c *cli.Context) error {

--- a/commands/hosts/add.go
+++ b/commands/hosts/add.go
@@ -1,9 +1,8 @@
 package hosts
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/config"
 )
 
 var hostAddCommand = cli.Command{
@@ -14,6 +13,15 @@ var hostAddCommand = cli.Command{
 }
 
 func cmfAdd(c *cli.Context) error {
-	fmt.Println("hosts add")
+	name := c.Args().Get(0)
+	addr := c.Args().Get(1)
+	if name == "" || addr == "" {
+		return cli.NewExitError("'add' requires 2 arguments", 1)
+	}
+
+	err := config.Config.AddHost(config.NewHostConfig(name, addr))
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
 	return nil
 }

--- a/commands/hosts/change.go
+++ b/commands/hosts/change.go
@@ -8,10 +8,9 @@ import (
 )
 
 var hostChangeCommand = cli.Command{
-	Name: "change",
-	Usage: "change the Synse Server instance to interface with",
+	Name:   "change",
+	Usage:  "change the Synse Server instance to interface with",
 	Action: cmdChange,
-
 }
 
 func cmdChange(c *cli.Context) error {

--- a/commands/hosts/change.go
+++ b/commands/hosts/change.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/config"
 )
 
 var hostChangeCommand = cli.Command{
@@ -14,6 +15,16 @@ var hostChangeCommand = cli.Command{
 }
 
 func cmdChange(c *cli.Context) error {
-	fmt.Println("hosts change")
-	return nil
+	name := c.Args().Get(0)
+	if name == "" {
+		return cli.NewExitError("'change' requires 1 argument", 1)
+	}
+
+	for _, host := range config.Config.Hosts {
+		if host.Name == name {
+			config.Config.ActiveHost = host
+			return nil
+		}
+	}
+	return cli.NewExitError(fmt.Sprintf("host with name '%v' not found", name), 1)
 }

--- a/commands/hosts/cmd.go
+++ b/commands/hosts/cmd.go
@@ -7,7 +7,7 @@ import (
 // NewHostsCommand
 func NewHostsCommand() cli.Command {
 	return cli.Command{
-		Name: "hosts",
+		Name:  "hosts",
 		Usage: "manage the configured Synse Server instances",
 		Subcommands: []cli.Command{
 			hostsActiveCommand,

--- a/commands/hosts/delete.go
+++ b/commands/hosts/delete.go
@@ -6,10 +6,9 @@ import (
 )
 
 var hostDeleteCommand = cli.Command{
-Name: "delete",
-Usage: "delete a Synse Server instance configuration",
-Action: cmdDelete,
-
+	Name:   "delete",
+	Usage:  "delete a Synse Server instance configuration",
+	Action: cmdDelete,
 }
 
 func cmdDelete(c *cli.Context) error {

--- a/commands/hosts/delete.go
+++ b/commands/hosts/delete.go
@@ -1,19 +1,29 @@
 package hosts
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/config"
 )
 
 var hostDeleteCommand = cli.Command{
-	Name: "delete",
-	Usage: "delete a Synse Server instance configuration",
-	Action: cmdDelete,
+Name: "delete",
+Usage: "delete a Synse Server instance configuration",
+Action: cmdDelete,
 
 }
 
 func cmdDelete(c *cli.Context) error {
-	fmt.Println("hosts delete")
+	name := c.Args().Get(0)
+	if name == "" {
+		return cli.NewExitError("'delete' requires 1 argument", 1)
+	}
+
+	host := config.Config.Hosts[name]
+	if host != nil {
+		if *host == *config.Config.ActiveHost {
+			config.Config.ActiveHost = nil
+		}
+	}
+	delete(config.Config.Hosts, name)
 	return nil
 }

--- a/commands/hosts/list.go
+++ b/commands/hosts/list.go
@@ -2,15 +2,14 @@ package hosts
 
 import (
 	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-cli/config"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 var hostsListCommand = cli.Command{
-	Name: "list",
-	Usage: "list the configured Synse Server hosts",
+	Name:   "list",
+	Usage:  "list the configured Synse Server hosts",
 	Action: cmdList,
-
 }
 
 func cmdList(c *cli.Context) error {

--- a/commands/hosts/list.go
+++ b/commands/hosts/list.go
@@ -1,9 +1,9 @@
 package hosts
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/config"
 )
 
 var hostsListCommand = cli.Command{
@@ -14,6 +14,20 @@ var hostsListCommand = cli.Command{
 }
 
 func cmdList(c *cli.Context) error {
-	fmt.Println("hosts list")
+	var data [][]string
+	for _, host := range config.Config.Hosts {
+		isActive := ""
+		if config.Config.ActiveHost != nil && *host == *config.Config.ActiveHost {
+			isActive = "*"
+		}
+		data = append(data, []string{
+			isActive,
+			host.Name,
+			host.Address,
+		})
+	}
+
+	// FIXME (etd) - data should be sorted
+	utils.MinimalTableOutput(data)
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,9 +12,9 @@ import (
 )
 
 type config struct {
-	Debug bool
+	Debug      bool
 	ActiveHost *hostConfig
-	Hosts map[string]*hostConfig
+	Hosts      map[string]*hostConfig
 }
 
 // AddHosts adds the given host to the configuration. If the host already exists
@@ -32,20 +32,18 @@ func (c *config) AddHost(host *hostConfig) error {
 }
 
 type hostConfig struct {
-	Name string
+	Name    string
 	Address string
 }
 
 // Config is a new variable containing the config object
 var Config config
 
-
 var configName = ".synse"
-
 
 func NewHostConfig(name, address string) *hostConfig {
 	return &hostConfig{
-		Name: name,
+		Name:    name,
 		Address: address,
 	}
 }
@@ -71,7 +69,7 @@ func ConstructConfig(c *cli.Context) error {
 
 	// add a default "local" instance of Synse Server
 	Config.AddHost(&hostConfig{
-		Name: "local",
+		Name:    "local",
 		Address: "localhost:5000",
 	})
 

--- a/config/utils.go
+++ b/config/utils.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"os"
+	"fmt"
+	"io/ioutil"
+	"gopkg.in/yaml.v2"
+	log "github.com/Sirupsen/logrus"
+)
+
+// Persist writes the current configuration to file.
+func Persist() error {
+
+	// First, check if an existing configuration file exists.
+	configPath, err := getConfigPath()
+	if err != nil {
+		return err
+	}
+
+	// If an existing file does not exist, create one
+	if configPath == "" {
+		configPath = filepath.Join(os.Getenv("HOME"), configName + ".yml")
+	}
+
+	log.WithFields(log.Fields{
+		"path": configPath,
+	}).Debug("Persisting config")
+
+	data, err := yaml.Marshal(Config)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(configPath, data, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+
+
+// getConfigPath
+func getConfigPath(paths ...string) (string, error) {
+
+	var found []string
+
+	for _, path := range paths {
+
+		if strings.HasPrefix(path, "$HOME") {
+			path = os.Getenv("HOME") + path[5:]
+		}
+
+		// First check if a configuration file exists, either in the current working
+		// directory or in the $HOME directory.
+		fullPath := filepath.Join(path, configName)
+		matches, err := filepath.Glob(fullPath + ".*")
+		if err != nil {
+			return "", err
+		}
+
+		for _, match := range matches {
+			ext := filepath.Ext(match)
+
+			switch strings.ToLower(ext) {
+			case ".yaml", ".yml":
+				found = append(found, match)
+
+			default:
+			}
+		}
+	}
+
+	if len(found) == 0 {
+		return "", nil
+	}
+
+	if len(found) >= 2 {
+		return "", fmt.Errorf("found more than one possible configurations - can only have one")
+	}
+
+	// Only one was found, so return it
+	return found[0], nil
+}

--- a/config/utils.go
+++ b/config/utils.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"path/filepath"
-	"strings"
-	"os"
 	"fmt"
 	"io/ioutil"
-	"gopkg.in/yaml.v2"
+	"os"
+	"path/filepath"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 // Persist writes the current configuration to file.
@@ -21,7 +22,7 @@ func Persist() error {
 
 	// If an existing file does not exist, create one
 	if configPath == "" {
-		configPath = filepath.Join(os.Getenv("HOME"), configName + ".yml")
+		configPath = filepath.Join(os.Getenv("HOME"), configName+".yml")
 	}
 
 	log.WithFields(log.Fields{
@@ -39,8 +40,6 @@ func Persist() error {
 
 	return nil
 }
-
-
 
 // getConfigPath
 func getConfigPath(paths ...string) (string, error) {

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -9,7 +9,6 @@ var debugFlag = cli.BoolFlag{
 	Usage: "enable debug mode",
 }
 
-
 var Flags = []cli.Flag{
 	debugFlag,
 }

--- a/synse.go
+++ b/synse.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vapor-ware/synse-cli/config"
 	"github.com/vapor-ware/synse-cli/commands"
+	"github.com/vapor-ware/synse-cli/config"
 	"github.com/vapor-ware/synse-cli/flags"
 
 	log "github.com/Sirupsen/logrus"

--- a/synse.go
+++ b/synse.go
@@ -54,5 +54,13 @@ func main() {
 		return nil
 	}
 
+	app.After = func(c *cli.Context) error {
+		err := config.Persist()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	app.Run(os.Args)
 }

--- a/utils/table.go
+++ b/utils/table.go
@@ -21,6 +21,15 @@ func TableOutput(header []string, data [][]string) {
 	table.Render()
 }
 
+// MinimalTableOutput renders a table with no borders, separators, or headers.
+func MinimalTableOutput(data [][]string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorder(false)
+	table.SetColumnSeparator("")
+	table.AppendBulk(data)
+	table.Render()
+}
+
 // ProgressBar renders an instance of the progress bar with the default configuration
 // values.
 func ProgressBar(length int, title string) (*mpb.Bar, *mpb.Progress) {


### PR DESCRIPTION
this adds functionality for the `synse hosts` subcommands
- active
- add
- change
- delete
- list

there is still cleanup to be done, but this gets the base functionality in. 

if no config file is detected, one will be created to persist host info. if one exists, it will be updated.