### PR TITLE
2.0 cmds

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -79,27 +79,17 @@ import (
 	"github.com/vapor-ware/synse-cli/commands/hosts"
 
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/commands/server"
 )
 
 // Commands provides the global list of commands to app.cli.
 // Definitions, usage information, and executed functions are given.
 var Commands = []cli.Command{
 	hosts.NewHostsCommand(),
-	{
-		Name:    "status",
-		Aliases: []string{"stat"},
-		Usage:   "Get the status of the current deployment",
-		Action: func(c *cli.Context) error {
-			return utils.CommandHandler(c, TestAPI())
-		},
-	},
-	{
-		Name:  "scan",
-		Usage: "Scan the infrastructure and display device summary",
-		Action: func(c *cli.Context) error {
-			return utils.CommandHandler(c, Scan())
-		},
-	},
+	server.StatusCommand,
+	server.VersionCommand,
+	server.ScanCommand,
+	server.ConfigCommand,
 	{
 		Name:  "assets",
 		Usage: "Manage and get information about physical devices",

--- a/commands/server/cmd.go
+++ b/commands/server/cmd.go
@@ -1,0 +1,10 @@
+package server
+
+import "github.com/urfave/cli"
+
+// NewHostsCommand
+func NewServerCommands() []cli.Command {
+	return []cli.Command{
+		StatusCommand,
+	}
+}

--- a/commands/server/config.go
+++ b/commands/server/config.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+	"gopkg.in/yaml.v2"
+)
+
+// configURI
+const configURI = "config"
+
+// configCommand
+var ConfigCommand = cli.Command{
+	Name:    "config",
+	Usage:   "get the configuration of the active Synse Server instance",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdConfig(c))
+	},
+}
+
+// cmdConfig
+func cmdConfig(c *cli.Context) error {
+	cfg := &scheme.Config{}
+	resp, err := client.New().Get(configURI).ReceiveSuccess(cfg)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", out)
+	return nil
+}

--- a/commands/server/config.go
+++ b/commands/server/config.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -15,8 +16,8 @@ const configURI = "config"
 
 // configCommand
 var ConfigCommand = cli.Command{
-	Name:    "config",
-	Usage:   "get the configuration of the active Synse Server instance",
+	Name:  "config",
+	Usage: "get the configuration of the active Synse Server instance",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdConfig(c))
 	},

--- a/commands/server/info.go
+++ b/commands/server/info.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// infoURI
+const infoURI = "info"
+
+// infoCommand
+var infoCommand = cli.Command{
+	Name:    "info",
+	Usage:   "info",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdInfo(c))
+	},
+}
+
+// cmdInfo
+func cmdInfo(c *cli.Context) error {
+	// FIXME - need to discern between rack, board, and device info
+	info := &scheme.RackInfo{}
+	resp, err := client.New().Get(infoURI).ReceiveSuccess(info)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	fmt.Println("unimplemented")
+	return nil
+}

--- a/commands/server/info.go
+++ b/commands/server/info.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // infoURI
@@ -14,8 +15,8 @@ const infoURI = "info"
 
 // infoCommand
 var infoCommand = cli.Command{
-	Name:    "info",
-	Usage:   "info",
+	Name:  "info",
+	Usage: "info",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdInfo(c))
 	},

--- a/commands/server/read.go
+++ b/commands/server/read.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // readURI
@@ -14,8 +15,8 @@ const readURI = "read"
 
 // readCommand
 var readCommand = cli.Command{
-	Name:    "read",
-	Usage:   "read",
+	Name:  "read",
+	Usage: "read",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdRead(c))
 	},

--- a/commands/server/read.go
+++ b/commands/server/read.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// readURI
+const readURI = "read"
+
+// readCommand
+var readCommand = cli.Command{
+	Name:    "read",
+	Usage:   "read",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdRead(c))
+	},
+}
+
+// cmdRead
+func cmdRead(c *cli.Context) error {
+	read := &scheme.Read{}
+	resp, err := client.New().Get(readURI).ReceiveSuccess(read)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	fmt.Println("unimplemented")
+	return nil
+}

--- a/commands/server/scan.go
+++ b/commands/server/scan.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+)
+
+// scanURI
+const scanURI = "scan"
+
+// statusCommand
+var ScanCommand = cli.Command{
+	Name:    "scan",
+	Usage:   "scan the Synse Server instance",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdScan(c))
+	},
+}
+
+// cmdScan
+func cmdScan(c *cli.Context) error {
+	scan := &scheme.Scan{}
+	resp, err := client.New().Get(scanURI).ReceiveSuccess(scan)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	// FIXME -- the below doesn't work anymore ):
+	var data [][]string
+
+	filter := &utils.FilterFunc{}
+	filter.FilterFn = func(res utils.Result) bool {
+		return true
+	}
+
+	fil, err := utils.FilterDevices(filter)
+	if err != nil {
+		return err
+	}
+	for res := range fil {
+		if res.Error != nil {
+			return res.Error
+		}
+		data = append(data, []string{
+
+		})
+	}
+
+	header := []string{"Rack", "Board", "Device", "Info", "Type"}
+	utils.TableOutput(header, data)
+	return nil
+}

--- a/commands/server/scan.go
+++ b/commands/server/scan.go
@@ -1,11 +1,12 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
 	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // scanURI
@@ -13,8 +14,8 @@ const scanURI = "scan"
 
 // statusCommand
 var ScanCommand = cli.Command{
-	Name:    "scan",
-	Usage:   "scan the Synse Server instance",
+	Name:  "scan",
+	Usage: "scan the Synse Server instance",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdScan(c))
 	},
@@ -48,9 +49,7 @@ func cmdScan(c *cli.Context) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		data = append(data, []string{
-
-		})
+		data = append(data, []string{})
 	}
 
 	header := []string{"Rack", "Board", "Device", "Info", "Type"}

--- a/commands/server/status.go
+++ b/commands/server/status.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// testURI
+const testURI = "test"
+
+// statusCommand
+var StatusCommand = cli.Command{
+	Name:    "status",
+	Usage:   "get the status of the active Synse Server instance",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdStatus(c))
+	},
+}
+
+// cmdStatus
+func cmdStatus(c *cli.Context) error {
+	status := &scheme.TestStatus{}
+	resp, err := client.NewUnversioned().Get(testURI).ReceiveSuccess(status)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+	fmt.Printf("status:    %s\n", status.Status)
+	fmt.Printf("timestamp: %s\n", status.Timestamp)
+	return nil
+}

--- a/commands/server/status.go
+++ b/commands/server/status.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // testURI
@@ -14,8 +15,8 @@ const testURI = "test"
 
 // statusCommand
 var StatusCommand = cli.Command{
-	Name:    "status",
-	Usage:   "get the status of the active Synse Server instance",
+	Name:  "status",
+	Usage: "get the status of the active Synse Server instance",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdStatus(c))
 	},

--- a/commands/server/transaction.go
+++ b/commands/server/transaction.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // transactionURI
@@ -14,8 +15,8 @@ const transactionURI = "transaction"
 
 // transactionCommand
 var transactionCommand = cli.Command{
-	Name:    "transaction",
-	Usage:   "transaction",
+	Name:  "transaction",
+	Usage: "transaction",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdTransaction(c))
 	},

--- a/commands/server/transaction.go
+++ b/commands/server/transaction.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// transactionURI
+const transactionURI = "transaction"
+
+// transactionCommand
+var transactionCommand = cli.Command{
+	Name:    "transaction",
+	Usage:   "transaction",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdTransaction(c))
+	},
+}
+
+// cmdTransaction
+func cmdTransaction(c *cli.Context) error {
+	transaction := &scheme.Transaction{}
+	resp, err := client.New().Get(transactionURI).ReceiveSuccess(transaction)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	fmt.Println("unimplemented")
+	return nil
+}

--- a/commands/server/version.go
+++ b/commands/server/version.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // versionURI
@@ -14,8 +15,8 @@ const versionURI = "version"
 
 // versionCommand
 var VersionCommand = cli.Command{
-	Name:    "version",
-	Usage:   "get the version of the active Synse Server instance",
+	Name:  "version",
+	Usage: "get the version of the active Synse Server instance",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdVersion(c))
 	},

--- a/commands/server/version.go
+++ b/commands/server/version.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// versionURI
+const versionURI = "version"
+
+// versionCommand
+var VersionCommand = cli.Command{
+	Name:    "version",
+	Usage:   "get the version of the active Synse Server instance",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdVersion(c))
+	},
+}
+
+// cmdVersion
+func cmdVersion(c *cli.Context) error {
+	version := &scheme.Version{}
+	resp, err := client.NewUnversioned().Get(versionURI).ReceiveSuccess(version)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+	fmt.Printf("api version: %s\n", version.APIVersion)
+	fmt.Printf("version:     %s\n", version.Version)
+	return nil
+}

--- a/commands/server/write.go
+++ b/commands/server/write.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/utils"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/client"
+	"net/http"
+	"fmt"
+)
+
+// writeURI
+const writeURI = "write"
+
+// writeCommand
+var writeCommand = cli.Command{
+	Name:    "write",
+	Usage:   "write",
+	Action: func(c *cli.Context) error {
+		return utils.CommandHandler(c, cmdWrite(c))
+	},
+}
+
+// cmdWrite
+func cmdWrite(c *cli.Context) error {
+	write := &scheme.Write{}
+	resp, err := client.New().Get(writeURI).ReceiveSuccess(write)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
+	fmt.Println("unimplemented")
+	return nil
+}

--- a/commands/server/write.go
+++ b/commands/server/write.go
@@ -1,12 +1,13 @@
 package server
 
 import (
-	"github.com/urfave/cli"
-	"github.com/vapor-ware/synse-cli/utils"
-	"github.com/vapor-ware/synse-cli/scheme"
-	"github.com/vapor-ware/synse-cli/client"
-	"net/http"
 	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/client"
+	"github.com/vapor-ware/synse-cli/scheme"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // writeURI
@@ -14,8 +15,8 @@ const writeURI = "write"
 
 // writeCommand
 var writeCommand = cli.Command{
-	Name:    "write",
-	Usage:   "write",
+	Name:  "write",
+	Usage: "write",
 	Action: func(c *cli.Context) error {
 		return utils.CommandHandler(c, cmdWrite(c))
 	},

--- a/scheme/config.go
+++ b/scheme/config.go
@@ -1,0 +1,9 @@
+package scheme
+
+type Config struct {
+	Locale string `json:"locale",yaml:"locale"`
+	PrettyJSON bool `json:"pretty_json",yaml:"pretty_json"`
+	Logging string `json:"logging",yaml:"logging"`
+	Cache map[string]interface{} `json:"cache",yaml:"cache"`
+	GRPC map[string]interface{} `json:"grpc",yaml:"grpc"`
+}

--- a/scheme/config.go
+++ b/scheme/config.go
@@ -1,9 +1,9 @@
 package scheme
 
 type Config struct {
-	Locale string `json:"locale",yaml:"locale"`
-	PrettyJSON bool `json:"pretty_json",yaml:"pretty_json"`
-	Logging string `json:"logging",yaml:"logging"`
-	Cache map[string]interface{} `json:"cache",yaml:"cache"`
-	GRPC map[string]interface{} `json:"grpc",yaml:"grpc"`
+	Locale     string                 `json:"locale",yaml:"locale"`
+	PrettyJSON bool                   `json:"pretty_json",yaml:"pretty_json"`
+	Logging    string                 `json:"logging",yaml:"logging"`
+	Cache      map[string]interface{} `json:"cache",yaml:"cache"`
+	GRPC       map[string]interface{} `json:"grpc",yaml:"grpc"`
 }

--- a/utils/devices.go
+++ b/utils/devices.go
@@ -25,12 +25,12 @@ type scanResponse struct {
 // Rack contains the top level objects for a rack
 type Rack struct {
 	Boards []Board `json:"boards"`
-	RackID string  `json:"rack_id"`
+	RackID string  `json:"id"`
 }
 
 // Board contains the top level objects for a board
 type Board struct {
-	BoardID     string   `json:"board_id"`
+	BoardID     string   `json:"id"`
 	Hostnames   []string `json:"hostnames"`
 	IPAddresses []string `json:"ip_addresses"`
 	Devices     []Device `json:"devices"`
@@ -38,9 +38,9 @@ type Board struct {
 
 // Device contains the response values for a specific device
 type Device struct {
-	DeviceID   string `json:"device_id"`
-	DeviceInfo string `json:"device_info"`
-	DeviceType string `json:"device_type"`
+	DeviceID   string `json:"id"`
+	DeviceInfo string `json:"info"`
+	DeviceType string `json:"type"`
 }
 
 // Result gathers the response values for all nested objects


### PR DESCRIPTION
start to add in 2.0 commands. with this, the following work against a local synse-server instance
- status (test)
   ```
   edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (2.0-cmds) ➜ ./build/synse status
   status:    ok
   timestamp: 2018-02-05 17:22:13.567662
   ```
- version
   ```
   edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (2.0-cmds) ➜ ./build/synse version
   api version: 2.0
   version:     2.0.0
   ```
- config
   ```
   edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (2.0-cmds) ➜ ./build/synse config
   locale: en_US
   prettyjson: true
   logging: debug
   cache:
     meta:
       ttl: 20
     transaction:
       ttl: 20
   grpc:
     timeout: 20
   ```

stubs have been added in for the read, write, transaction, info, and scan commands. 

as per usual, there is still a lot to do and a lot to clean up here. this PR is more just a checkpoint of progress.