### PR TITLE
fix config output yaml formatting

### DIFF
--- a/scheme/config.go
+++ b/scheme/config.go
@@ -2,9 +2,9 @@ package scheme
 
 // Config is the scheme for the Synse Server "config" endpoint response.
 type Config struct {
-	Locale     string                 `json:"locale",yaml:"locale"`
-	PrettyJSON bool                   `json:"pretty_json",yaml:"pretty_json"`
-	Logging    string                 `json:"logging",yaml:"logging"`
-	Cache      map[string]interface{} `json:"cache",yaml:"cache"`
-	GRPC       map[string]interface{} `json:"grpc",yaml:"grpc"`
+	Locale     string                 `json:"locale" yaml:"locale"`
+	PrettyJSON bool                   `json:"pretty_json" yaml:"pretty_json"`
+	Logging    string                 `json:"logging" yaml:"logging"`
+	Cache      map[string]interface{} `json:"cache" yaml:"cache"`
+	GRPC       map[string]interface{} `json:"grpc" yaml:"grpc"`
 }


### PR DESCRIPTION
fixes #84 

turns out that when specifying multiple struct field annotations, you need to separate with a space, not a comma.