### PR TITLE
add basic filtering to scan command

### DIFF
--- a/flags/command.go
+++ b/flags/command.go
@@ -10,3 +10,9 @@ var OutputFlag = cli.StringFlag{
 	Value: "yaml",
 	Usage: "set the output format of the command",
 }
+
+// FilterFlag is the flag for setting a filter on a command's output.
+var FilterFlag = cli.StringFlag{
+	Name:  "filter, f",
+	Usage: "set a filter for the output results",
+}


### PR DESCRIPTION
fixes #77 

this adds basic filtering. right now only for type. there may be a better way to do this and it certainly could be cleaned up / organized better, but this at least gets it in.

```
edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (scan-filter) ➜ ./build/synse scan
  ID                                           INFO                        TYPE         
--------------------------------------------------------------------------------------
  rack-1-vec-329a91c6781ce92370a3c38ba9bf35b2  Synse Temperature Sensor 4  temperature  
  rack-1-vec-83cc1efe7e596e4ab6769e0c6e3edf88  Synse Temperature Sensor 2  temperature  
  rack-1-vec-d29e0bd113a484dc48fd55bd3abad6bb  Synse backup LED            led          
  rack-1-vec-db1e5deb43d9d0af6d80885e74362913  Synse Temperature Sensor 3  temperature  
  rack-1-vec-eb100067acb0c054cf877759db376b03  Synse Temperature Sensor 1  temperature  
  rack-1-vec-eb9a56f95b5bd6d9b51996ccd0f2329c  Synse Fan                   fan          
  rack-1-vec-f52d29fecf05a195af13f14c7306cfed  Synse LED                   led          
  rack-1-vec-f97f284037b04badb6bb7aacd9654a4e  Synse Temperature Sensor 5  temperature  

edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (scan-filter) ➜ ./build/synse scan --filter type=temperature
  ID                                           INFO                        TYPE         
--------------------------------------------------------------------------------------
  rack-1-vec-329a91c6781ce92370a3c38ba9bf35b2  Synse Temperature Sensor 4  temperature  
  rack-1-vec-83cc1efe7e596e4ab6769e0c6e3edf88  Synse Temperature Sensor 2  temperature  
  rack-1-vec-db1e5deb43d9d0af6d80885e74362913  Synse Temperature Sensor 3  temperature  
  rack-1-vec-eb100067acb0c054cf877759db376b03  Synse Temperature Sensor 1  temperature  
  rack-1-vec-f97f284037b04badb6bb7aacd9654a4e  Synse Temperature Sensor 5  temperature  
```