### PR TITLE
generalize output formatting

### DIFF
--- a/commands/plugin/metainfo.go
+++ b/commands/plugin/metainfo.go
@@ -2,72 +2,40 @@ package plugin
 
 import (
 	"io"
-	"os"
-	"text/tabwriter"
-	"text/template"
 
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/formatters/plugin"
+	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 )
 
-const (
-	metaTmpl = "{{.ID}}\t{{.Type}}\t{{.Model}}\t{{.Protocol}}\t{{.Rack}}\t{{.Board}}\n"
-)
-
-type scanOut struct {
-	ID       string
-	Type     string
-	Model    string
-	Protocol string
-	Rack     string
-	Board    string
-}
-
-var metaHeader = scanOut{
-	ID:       "ID",
-	Type:     "TYPE",
-	Model:    "MODEL",
-	Protocol: "PROTOCOL",
-	Rack:     "RACK",
-	Board:    "BOARD",
-}
-
 // pluginMetainfoCommand is a CLI sub-command for getting metainfo from a plugin.
 var pluginMetainfoCommand = cli.Command{
-	Name:   "meta",
-	Usage:  "Get the metainformation from a plugin",
-	Action: cmdMeta,
+	Name:  "meta",
+	Usage: "Get the metainformation from a plugin",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdMeta(c))
+	},
 }
 
 // cmdMeta is the action for pluginMetainfoCommand. It prints out the meta-information
 // provided by the specified plugin.
 func cmdMeta(c *cli.Context) error {
-	plugin, err := makeGrpcClient(c)
+	pluginClient, err := makeGrpcClient(c)
 	if err != nil {
 		return err
 	}
 
-	stream, err := plugin.Metainfo(
+	stream, err := pluginClient.Metainfo(
 		context.Background(),
 		&synse.MetainfoRequest{},
 	)
-
 	if err != nil {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
-
-	tmpl, err := template.New("meta").Parse(metaTmpl)
-	if err != nil {
-		return err
-	}
-	err = tmpl.Execute(w, metaHeader)
-	if err != nil {
-		return err
-	}
-
+	formatter := plugin.NewMetaFormatter(c.App.Writer)
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
@@ -76,21 +44,11 @@ func cmdMeta(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-
-		metaInfo := scanOut{
-			ID:       resp.Uid,
-			Type:     resp.Type,
-			Model:    resp.Model,
-			Protocol: resp.Protocol,
-			Rack:     resp.Location.Rack,
-			Board:    resp.Location.Board,
-		}
-
-		err = tmpl.Execute(w, metaInfo)
+		err = formatter.Add(resp)
 		if err != nil {
 			return err
 		}
 	}
 
-	return w.Flush()
+	return formatter.Write()
 }

--- a/commands/plugin/read.go
+++ b/commands/plugin/read.go
@@ -2,37 +2,21 @@ package plugin
 
 import (
 	"io"
-	"os"
-	"text/tabwriter"
-	"text/template"
 
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/formatters/plugin"
 	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 )
 
-const (
-	readTmpl = "{{.ID}}\t{{.Type}}\t{{.Reading}}\n"
-)
-
-type readOut struct {
-	ID      string
-	Type    string
-	Reading string
-}
-
-var readHeader = readOut{
-	ID:      "ID",
-	Type:    "TYPE",
-	Reading: "READING",
-}
-
 // pluginReadCommand is a CLI sub-command for getting a reading from a plugin.
 var pluginReadCommand = cli.Command{
-	Name:   "read",
-	Usage:  "Get a reading from a plugin",
-	Action: cmdRead,
+	Name:  "read",
+	Usage: "Get a reading from a plugin",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdRead(c))
+	},
 }
 
 // cmdRead is the action for pluginReadCommand. It prints out a reading that was
@@ -47,12 +31,12 @@ func cmdRead(c *cli.Context) error { // nolint: gocyclo
 	board := c.Args().Get(1)
 	device := c.Args().Get(2)
 
-	plugin, err := makeGrpcClient(c)
+	pluginClient, err := makeGrpcClient(c)
 	if err != nil {
 		return err
 	}
 
-	stream, err := plugin.Read(context.Background(), &synse.ReadRequest{
+	stream, err := pluginClient.Read(context.Background(), &synse.ReadRequest{
 		Device: device,
 		Board:  board,
 		Rack:   rack,
@@ -61,17 +45,7 @@ func cmdRead(c *cli.Context) error { // nolint: gocyclo
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
-
-	tmpl, err := template.New("read").Parse(readTmpl)
-	if err != nil {
-		return err
-	}
-	err = tmpl.Execute(w, readHeader)
-	if err != nil {
-		return err
-	}
-
+	formatter := plugin.NewReadFormatter(c.App.Writer)
 	for {
 		resp, err := stream.Recv()
 		if err == io.EOF {
@@ -80,19 +54,10 @@ func cmdRead(c *cli.Context) error { // nolint: gocyclo
 		if err != nil {
 			return err
 		}
-
-		reading := readOut{
-			ID:      device,
-			Type:    resp.Type,
-			Reading: resp.Value,
-		}
-
-		err = tmpl.Execute(w, reading)
+		err = formatter.Add(resp)
 		if err != nil {
 			return err
 		}
-
 	}
-
-	return w.Flush()
+	return formatter.Write()
 }

--- a/commands/plugin/transaction.go
+++ b/commands/plugin/transaction.go
@@ -1,41 +1,20 @@
 package plugin
 
 import (
-	"os"
-	"text/tabwriter"
-	"text/template"
-
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/formatters/plugin"
 	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 )
 
-const (
-	transactionTmpl = "{{.ID}}\t{{.Status}}\t{{.State}}\t{{.Created}}\t{{.Updated}}\n"
-)
-
-type transactionOut struct {
-	ID      string
-	Status  string
-	State   string
-	Created string
-	Updated string
-}
-
-var transactionHeader = transactionOut{
-	ID:      "ID",
-	Status:  "STATUS",
-	State:   "STATE",
-	Created: "CREATED",
-	Updated: "UPDATED",
-}
-
 // pluginTransactionCommand is a CLI sub-command for getting transaction info from a plugin.
 var pluginTransactionCommand = cli.Command{
-	Name:   "transaction",
-	Usage:  "Get transaction info from a plugin",
-	Action: cmdTransaction,
+	Name:  "transaction",
+	Usage: "Get transaction info from a plugin",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdTransaction(c))
+	},
 }
 
 // cmdTransaction is the action for pluginTransactionCommand. It prints out transaction info
@@ -48,41 +27,22 @@ func cmdTransaction(c *cli.Context) error {
 
 	tid := c.Args().Get(0)
 
-	plugin, err := makeGrpcClient(c)
+	pluginClient, err := makeGrpcClient(c)
 	if err != nil {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
+	formatter := plugin.NewTransactionFormatter(c.App.Writer)
 
-	tmpl, err := template.New("transaction").Parse(transactionTmpl)
-	if err != nil {
-		return err
-	}
-	err = tmpl.Execute(w, transactionHeader)
-	if err != nil {
-		return err
-	}
-
-	status, err := plugin.TransactionCheck(context.Background(), &synse.TransactionId{
+	status, err := pluginClient.TransactionCheck(context.Background(), &synse.TransactionId{
 		Id: tid,
 	})
 	if err != nil {
 		return err
 	}
-
-	transaction := transactionOut{
-		ID:      tid,
-		Status:  status.Status.String(),
-		State:   status.State.String(),
-		Created: status.Created,
-		Updated: status.Updated,
-	}
-
-	err = tmpl.Execute(w, transaction)
+	err = formatter.Add(status)
 	if err != nil {
 		return err
 	}
-
-	return w.Flush()
+	return formatter.Write()
 }

--- a/commands/plugin/write.go
+++ b/commands/plugin/write.go
@@ -1,37 +1,20 @@
 package plugin
 
 import (
-	"os"
-	"text/tabwriter"
-	"text/template"
-
 	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/formatters/plugin"
 	"github.com/vapor-ware/synse-cli/utils"
 	"github.com/vapor-ware/synse-server-grpc/go"
 	"golang.org/x/net/context"
 )
 
-const (
-	writeTmpl = "{{.ID}}\t{{.Action}}\t{{.Raw}}\n"
-)
-
-type writeOut struct {
-	ID     string
-	Action string
-	Raw    string
-}
-
-var writeHeader = writeOut{
-	ID:     "TRANSACTION ID",
-	Action: "ACTION",
-	Raw:    "RAW",
-}
-
 // pluginWriteCommand is a CLI sub-command for writing to a plugin
 var pluginWriteCommand = cli.Command{
-	Name:   "write",
-	Usage:  "Write data directly to a plugin",
-	Action: cmdWrite,
+	Name:  "write",
+	Usage: "Write data directly to a plugin",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdWrite(c))
+	},
 }
 
 // cmdWrite is the action for pluginWriteCommand. It writes directly to
@@ -55,12 +38,12 @@ func cmdWrite(c *cli.Context) error { // nolint: gocyclo
 		wd.Raw = [][]byte{[]byte(raw)}
 	}
 
-	plugin, err := makeGrpcClient(c)
+	pluginClient, err := makeGrpcClient(c)
 	if err != nil {
 		return err
 	}
 
-	transactions, err := plugin.Write(context.Background(), &synse.WriteRequest{
+	transactions, err := pluginClient.Write(context.Background(), &synse.WriteRequest{
 		Device: device,
 		Board:  board,
 		Rack:   rack,
@@ -70,33 +53,10 @@ func cmdWrite(c *cli.Context) error { // nolint: gocyclo
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
-
-	tmpl, err := template.New("write").Parse(writeTmpl)
+	formatter := plugin.NewWriteFormatter(c.App.Writer)
+	err = formatter.Add(transactions)
 	if err != nil {
 		return err
 	}
-	err = tmpl.Execute(w, writeHeader)
-	if err != nil {
-		return err
-	}
-
-	for tid, ctx := range transactions.Transactions {
-		raw := ""
-		for _, i := range ctx.Raw {
-			raw += string(i) + " "
-		}
-
-		out := writeOut{
-			ID:     tid,
-			Action: ctx.Action,
-			Raw:    raw,
-		}
-		err = tmpl.Execute(w, out)
-		if err != nil {
-			return err
-		}
-	}
-
-	return w.Flush()
+	return formatter.Write()
 }

--- a/formatters/format.go
+++ b/formatters/format.go
@@ -1,0 +1,117 @@
+package formatters
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+const (
+	// TableFormat is the key used by a Format string to denote that the
+	// output should be a table.
+	TableFormat = "table"
+
+	// RawFormat is the key used by a Format string to denote that the
+	// output should be in its raw form.
+	RawFormat = "raw"
+)
+
+// Format is the output format for a command.
+type Format string
+
+// IsTable returns true if the format string has the "table" prefix.
+func (f Format) IsTable() bool {
+	return strings.HasPrefix(string(f), TableFormat)
+}
+
+// Formatter holds the context necessary to accumulate and format output
+// based on a given format string.
+type Formatter struct {
+	Format Format
+	Output io.Writer
+
+	handler      func(interface{}) (interface{}, error)
+	header       interface{}
+	data         []interface{}
+	parsedFormat string
+}
+
+// pre is the pre-action called before the writing of the formatted data.
+func (f *Formatter) pre() {
+	if f.Format.IsTable() {
+		// if the format string is for a table, set the parsedFormat as the
+		// format string without the 'table ' prefix (note the space included
+		// after the 'table' keyword)
+		f.parsedFormat = string(f.Format)[len(TableFormat)+1:]
+	}
+}
+
+// SetHandler sets the Formatter handler used by the `Add` function which
+// allows for command-specific formatting.
+func (f *Formatter) SetHandler(fn func(interface{}) (interface{}, error)) {
+	f.handler = fn
+}
+
+// SetHeader sets the header of the formatted output. The header is only
+// output if the Format is a table.
+func (f *Formatter) SetHeader(header interface{}) {
+	f.header = header
+}
+
+// Add adds an additional piece of data to output on `Write`. For a Formatter
+// processing for table, this can be thought of as adding a new row.
+func (f *Formatter) Add(data interface{}) error {
+	if f.handler == nil {
+		return fmt.Errorf("no handler set for the formatter")
+	}
+
+	d, err := f.handler(data)
+	if err != nil {
+		return err
+	}
+
+	l, ok := d.([]interface{})
+	if ok {
+		f.data = append(f.data, l...)
+	} else {
+		f.data = append(f.data, d)
+	}
+	return nil
+}
+
+// Write writes out the data and headers (if applicable) accumulated by the
+// Formatter to the output used by the CLI.
+func (f *Formatter) Write() error {
+	f.pre()
+
+	if f.Format.IsTable() {
+		w := tabwriter.NewWriter(f.Output, 10, 1, 3, ' ', 0)
+		tmpl, err := template.New("").Parse(f.parsedFormat)
+		if err != nil {
+			return err
+		}
+
+		err = tmpl.Execute(w, f.header)
+		if err != nil {
+			return err
+		}
+		for _, d := range f.data {
+			err := tmpl.Execute(w, d)
+			if err != nil {
+				return nil
+			}
+		}
+		return w.Flush()
+	}
+	return nil
+}
+
+// NewFormatter creates a new instance of a Formatter.
+func NewFormatter(format Format, out io.Writer) *Formatter {
+	return &Formatter{
+		Format: format,
+		Output: out,
+	}
+}

--- a/formatters/plugin/metainfo.go
+++ b/formatters/plugin/metainfo.go
@@ -1,0 +1,60 @@
+package plugin
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vapor-ware/synse-cli/formatters"
+	"github.com/vapor-ware/synse-server-grpc/go"
+)
+
+const (
+	// the default output template for plugin metainfo requests
+	metaTmpl = "table {{.ID}}\t{{.Type}}\t{{.Model}}\t{{.Protocol}}\t{{.Rack}}\t{{.Board}}\n"
+)
+
+// metaFormat collects the data that will be parsed into the output template.
+type metaFormat struct {
+	ID       string
+	Type     string
+	Model    string
+	Protocol string
+	Rack     string
+	Board    string
+}
+
+// newMetaFormat is the handler for plugin metainfo commands that is used by the
+// Formatter to add new metainfo data to the format context.
+func newMetaFormat(data interface{}) (interface{}, error) {
+	meta, ok := data.(*synse.MetainfoResponse)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type *MetainfoResponse", meta)
+	}
+	return &metaFormat{
+		ID:       meta.Uid,
+		Type:     meta.Type,
+		Model:    meta.Model,
+		Protocol: meta.Protocol,
+		Rack:     meta.Location.Rack,
+		Board:    meta.Location.Board,
+	}, nil
+}
+
+// NewMetaFormatter creates a new instance of a Formatter configured
+// for the plugin meta command.
+func NewMetaFormatter(out io.Writer) *formatters.Formatter {
+	f := formatters.NewFormatter(
+		metaTmpl,
+		out,
+	)
+	f.SetHandler(newMetaFormat)
+	f.SetHeader(metaFormat{
+		ID:       "ID",
+		Type:     "TYPE",
+		Model:    "MODEL",
+		Protocol: "PROTOCOL",
+		Rack:     "RACK",
+		Board:    "BOARD",
+	})
+	return f
+}

--- a/formatters/plugin/read.go
+++ b/formatters/plugin/read.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vapor-ware/synse-cli/formatters"
+	"github.com/vapor-ware/synse-server-grpc/go"
+)
+
+const (
+	// the default output template for plugin reads
+	readTmpl = "table {{.Type}}\t{{.Reading}}\t{{.Timestamp}}\n"
+)
+
+// readFormat collects the data that will be parsed into the output template.
+type readFormat struct {
+	Type      string
+	Reading   string
+	Timestamp string
+}
+
+// newReadFormat is the handler for plugin read commands that is used by the
+// Formatter to add new read data to the format context.
+func newReadFormat(data interface{}) (interface{}, error) {
+	read, ok := data.(*synse.ReadResponse)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type *ReadResponse", read)
+	}
+	return &readFormat{
+		Type:      read.Type,
+		Reading:   read.Value,
+		Timestamp: read.Timestamp,
+	}, nil
+}
+
+// NewReadFormatter creates a new instance of a Formatter configured
+// for the plugin read command.
+func NewReadFormatter(out io.Writer) *formatters.Formatter {
+	f := formatters.NewFormatter(
+		readTmpl,
+		out,
+	)
+	f.SetHandler(newReadFormat)
+	f.SetHeader(readFormat{
+		Type:      "TYPE",
+		Reading:   "READING",
+		Timestamp: "TIMESTAMP",
+	})
+	return f
+}

--- a/formatters/plugin/transaction.go
+++ b/formatters/plugin/transaction.go
@@ -1,0 +1,55 @@
+package plugin
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vapor-ware/synse-cli/formatters"
+	"github.com/vapor-ware/synse-server-grpc/go"
+)
+
+const (
+	// the default output template for plugin transaction checks
+	transactionTmpl = "table {{.Status}}\t{{.State}}\t{{.Created}}\t{{.Updated}}\n"
+)
+
+// transactionFormat collects the data that will be parsed into the output template.
+type transactionFormat struct {
+	Status  string
+	State   string
+	Created string
+	Updated string
+}
+
+// newTransactionFormat is the handler for plugin transaction commands that is used by the
+// Formatter to add new transaction data to the format context.
+func newTransactionFormat(data interface{}) (interface{}, error) {
+	transaction, ok := data.(*synse.WriteResponse)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type *WriteResponse", transaction)
+	}
+
+	return &transactionFormat{
+		Status:  transaction.Status.String(),
+		State:   transaction.State.String(),
+		Created: transaction.Created,
+		Updated: transaction.Updated,
+	}, nil
+}
+
+// NewTransactionFormatter creates a new instance of a Formatter configured
+// for the plugin transaction command.
+func NewTransactionFormatter(out io.Writer) *formatters.Formatter {
+	f := formatters.NewFormatter(
+		transactionTmpl,
+		out,
+	)
+	f.SetHandler(newTransactionFormat)
+	f.SetHeader(transactionFormat{
+		Status:  "STATUS",
+		State:   "STATE",
+		Created: "CREATED",
+		Updated: "UPDATED",
+	})
+	return f
+}

--- a/formatters/plugin/write.go
+++ b/formatters/plugin/write.go
@@ -1,0 +1,61 @@
+package plugin
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vapor-ware/synse-cli/formatters"
+	"github.com/vapor-ware/synse-server-grpc/go"
+)
+
+const (
+	// the default output template for plugin writes
+	writeTmpl = "table {{.ID}}\t{{.Action}}\t{{range .Raw}}{{.}} {{end}}\n"
+)
+
+// writeFormat collects the data that will be parsed into the output template.
+type writeFormat struct {
+	ID     string
+	Action string
+	Raw    []string
+}
+
+// newWriteFormat is the handler for plugin write commands that is used by the
+// Formatter to add new write data to the format context.
+func newWriteFormat(data interface{}) (interface{}, error) {
+	write, ok := data.(*synse.Transactions)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type *Transactions", write)
+	}
+
+	var out []interface{}
+	for id, ctx := range write.Transactions {
+		var raw []string
+		for _, r := range ctx.Raw {
+			raw = append(raw, string(r))
+		}
+
+		out = append(out, &writeFormat{
+			ID:     id,
+			Action: ctx.Action,
+			Raw:    raw,
+		})
+	}
+	return out, nil
+}
+
+// NewWriteFormatter creates a new instance of a Formatter configured
+// for the plugin write command.
+func NewWriteFormatter(out io.Writer) *formatters.Formatter {
+	f := formatters.NewFormatter(
+		writeTmpl,
+		out,
+	)
+	f.SetHandler(newWriteFormat)
+	f.SetHeader(writeFormat{
+		ID:     "TRANSACTION ID",
+		Action: "ACTION",
+		Raw:    []string{"RAW"},
+	})
+	return f
+}


### PR DESCRIPTION
this PR generalizes how output formatting is done for commands, so now there is a common backend/pattern to follow for commands. 

still need to update the formatting of a bunch of commands to use this, but the plugin commands all use this and output correctly. also with these changes, we should be able to test expected command output