### PR TITLE
update formatting for 'hosts' commands

### DIFF
--- a/commands/hosts/active.go
+++ b/commands/hosts/active.go
@@ -1,17 +1,22 @@
 package hosts
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli"
 	"github.com/vapor-ware/synse-cli/config"
+	"github.com/vapor-ware/synse-cli/flags"
+	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // hostsActiveCommand is the CLI sub-command for getting the active host.
 var hostsActiveCommand = cli.Command{
-	Name:   "active",
-	Usage:  "Display information for the active host",
-	Action: cmdActive,
+	Name:  "active",
+	Usage: "Display information for the active host",
+	Flags: []cli.Flag{
+		flags.OutputFlag,
+	},
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdActive(c))
+	},
 }
 
 // cmdActive is the action for hostsActiveCommand. It prints out the information
@@ -20,7 +25,5 @@ func cmdActive(c *cli.Context) error {
 	if config.Config.ActiveHost == nil {
 		return cli.NewExitError("no active host set", 1)
 	}
-	fmt.Printf("Name:    %s\n", config.Config.ActiveHost.Name)
-	fmt.Printf("Address: %s\n", config.Config.ActiveHost.Address)
-	return nil
+	return utils.FormatOutput(c, config.Config.ActiveHost)
 }

--- a/commands/hosts/add.go
+++ b/commands/hosts/add.go
@@ -9,9 +9,11 @@ import (
 // hostsAddCommand is the CLI sub-command for adding a new host to the CLI
 // configuration.
 var hostsAddCommand = cli.Command{
-	Name:   "add",
-	Usage:  "Add a new Synse Server host",
-	Action: cmdAdd,
+	Name:  "add",
+	Usage: "Add a new Synse Server host",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdAdd(c))
+	},
 }
 
 // cmdAdd is the action for hostsAddCommand. It adds the specified host to the

--- a/commands/hosts/change.go
+++ b/commands/hosts/change.go
@@ -10,9 +10,11 @@ import (
 
 // hostsChangeCommand is the CLI sub-command for changing the active host.
 var hostsChangeCommand = cli.Command{
-	Name:   "change",
-	Usage:  "Change the active host",
-	Action: cmdChange,
+	Name:  "change",
+	Usage: "Change the active host",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdChange(c))
+	},
 }
 
 // cmfChange is the action for hostsChangeCommand. It changes the active host to

--- a/commands/hosts/delete.go
+++ b/commands/hosts/delete.go
@@ -9,9 +9,11 @@ import (
 // hostsDeleteCommand is the CLI sub-command for deleting a host from the
 // CLI configuration.
 var hostsDeleteCommand = cli.Command{
-	Name:   "delete",
-	Usage:  "Delete a Synse Server host from configuration",
-	Action: cmdDelete,
+	Name:  "delete",
+	Usage: "Delete a Synse Server host from configuration",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdDelete(c))
+	},
 }
 
 // cmdDelete is the action for hostsDeleteCommand. It removes the specified host

--- a/commands/hosts/list.go
+++ b/commands/hosts/list.go
@@ -5,34 +5,21 @@ import (
 
 	"github.com/urfave/cli"
 	"github.com/vapor-ware/synse-cli/config"
+	"github.com/vapor-ware/synse-cli/formatters/hosts"
 	"github.com/vapor-ware/synse-cli/utils"
 )
 
 // hostsListCommand is the CLI sub-command for listing all configured hosts.
 var hostsListCommand = cli.Command{
-	Name:   "list",
-	Usage:  "List the configured Synse Server hosts",
-	Action: cmdList,
-}
-
-// hostInfo represents a single host to be listed.
-type hostInfo struct {
-	Active  string
-	Name    string
-	Address string
-}
-
-// ToRow converts a hostInfo to a table row.
-func (host *hostInfo) ToRow() []string {
-	return []string{
-		host.Active,
-		host.Name,
-		host.Address,
-	}
+	Name:  "list",
+	Usage: "List the configured Synse Server hosts",
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdList(c))
+	},
 }
 
 // byHostName is the container type for sorting
-type byHostName []*hostInfo
+type byHostName []*config.HostConfig
 
 func (h byHostName) Len() int {
 	return len(h)
@@ -49,27 +36,19 @@ func (h byHostName) Less(i, j int) bool {
 // cmdList is the action for hostsListCommand. It prints out all of the configured
 // hosts' names and addresses.
 func cmdList(c *cli.Context) error {
-	var hosts []*hostInfo
-	for _, host := range config.Config.Hosts {
-		isActive := ""
-		if config.Config.ActiveHost != nil && *host == *config.Config.ActiveHost {
-			isActive = "*"
-		}
-		hosts = append(hosts, &hostInfo{
-			Active:  isActive,
-			Name:    host.Name,
-			Address: host.Address,
-		})
+	var configuredHosts []*config.HostConfig
+	for _, c := range config.Config.Hosts {
+		configuredHosts = append(configuredHosts, c)
 	}
 
 	// Sort by host name
-	sort.Sort(byHostName(hosts))
+	sort.Sort(byHostName(configuredHosts))
 
-	var data [][]string
-	for _, host := range hosts {
-		data = append(data, host.ToRow())
+	// Format output
+	formatter := hosts.NewListFormatter(c.App.Writer)
+	err := formatter.Add(configuredHosts)
+	if err != nil {
+		return err
 	}
-
-	utils.MinimalTableOutput(data)
-	return nil
+	return formatter.Write()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,8 +31,13 @@ func (c *CliConfig) AddHost(host *HostConfig) error {
 
 // HostConfig holds the configuration information for a single Synse Server host.
 type HostConfig struct {
-	Name    string
-	Address string
+	Name    string `json:"name" yaml:"name"`
+	Address string `json:"address" yaml:"address"`
+}
+
+// IsActiveHost checks if the host is the current active host for the CLI.
+func (c *HostConfig) IsActiveHost() bool {
+	return Config.ActiveHost != nil && *c == *Config.ActiveHost
 }
 
 // Config is a new variable containing the config object

--- a/config/utils.go
+++ b/config/utils.go
@@ -26,7 +26,8 @@ func Persist() error {
 	}
 
 	log.WithFields(log.Fields{
-		"path": configPath,
+		"path":   configPath,
+		"config": fmt.Sprintf("%+v", Config),
 	}).Debug("Persisting config")
 
 	data, err := yaml.Marshal(Config)

--- a/formatters/format.go
+++ b/formatters/format.go
@@ -93,14 +93,17 @@ func (f *Formatter) Write() error {
 			return err
 		}
 
-		err = tmpl.Execute(w, f.header)
-		if err != nil {
-			return err
+		if f.header != nil {
+			err = tmpl.Execute(w, f.header)
+			if err != nil {
+				return err
+			}
 		}
+
 		for _, d := range f.data {
 			err := tmpl.Execute(w, d)
 			if err != nil {
-				return nil
+				return err
 			}
 		}
 		return w.Flush()

--- a/formatters/hosts/list.go
+++ b/formatters/hosts/list.go
@@ -1,0 +1,54 @@
+package hosts
+
+import (
+	"io"
+
+	"fmt"
+
+	"github.com/vapor-ware/synse-cli/config"
+	"github.com/vapor-ware/synse-cli/formatters"
+)
+
+const (
+	// the default output template for host list command
+	listTmpl = "table {{if .Active}}* {{else}}  {{end}}{{.Name}}\t{{.Address}}\n"
+)
+
+type listFormat struct {
+	Active  bool
+	Name    string
+	Address string
+}
+
+// newListFormat is the handler for host list commands that is used by the
+// Formatter to add new list data to the format context.
+func newListFormat(data interface{}) (interface{}, error) {
+	cfg, ok := data.([]*config.HostConfig)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type []*config.HostConfig", data)
+	}
+	var out []interface{}
+	for _, c := range cfg {
+		active := false
+		if c.IsActiveHost() {
+			active = true
+		}
+		out = append(out, &listFormat{
+			Active:  active,
+			Name:    c.Name,
+			Address: c.Address,
+		})
+	}
+	return out, nil
+}
+
+// NewListFormatter creates a new instance of a Formatter configured
+// for the host list command.
+func NewListFormatter(out io.Writer) *formatters.Formatter {
+	f := formatters.NewFormatter(
+		listTmpl,
+		out,
+	)
+	f.SetHandler(newListFormat)
+	return f
+}


### PR DESCRIPTION
this updates the output formatting for the `hosts` commands so they use the generalized formatting utils put together in an earlier PR