### PR TITLE
update timestamp formatting

### DIFF
--- a/pkg/formatters/read.go
+++ b/pkg/formatters/read.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/vapor-ware/synse-cli/pkg/scheme"
+	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
 const (
@@ -32,7 +33,7 @@ func newReadFormat(data interface{}) (interface{}, error) {
 		out = append(out, &readFormat{
 			Type:      readType,
 			Value:     fmt.Sprintf("%v", readData.Value),
-			Timestamp: readData.Timestamp,
+			Timestamp: utils.ParseTimestamp(readData.Timestamp),
 		})
 	}
 

--- a/pkg/formatters/transaction.go
+++ b/pkg/formatters/transaction.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/vapor-ware/synse-cli/pkg/scheme"
+	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
 const (
@@ -31,8 +32,8 @@ func newTransactionFormat(data interface{}) (interface{}, error) {
 	return &transactionFormat{
 		Status:  transaction.Status,
 		State:   transaction.State,
-		Created: transaction.Created,
-		Updated: transaction.Updated,
+		Created: utils.ParseTimestamp(transaction.Created),
+		Updated: utils.ParseTimestamp(transaction.Updated),
 	}, nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli"
 )
@@ -47,4 +48,15 @@ func RequiresArgsExact(count int, c *cli.Context) error {
 		)
 	}
 	return nil
+}
+
+// ParseTimestamp takes a timestamp string and attempts to parse it for RFC3339Nano.
+// If successfully parsed, that timestamp will be returned in a more human-readable
+// format, otherwise, the given timestamp is returned back.
+func ParseTimestamp(timestamp string) string {
+	t, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return timestamp
+	}
+	return t.Format(time.UnixDate)
 }


### PR DESCRIPTION
fixes #103 

```
edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (timestamp-formatting *) ➜ ./build/synse scan
RACK      BOARD     DEVICE                             INFO                         TYPE
rack-1    vec       329a91c6781ce92370a3c38ba9bf35b2   Synse Temperature Sensor 4   temperature
rack-1    vec       83cc1efe7e596e4ab6769e0c6e3edf88   Synse Temperature Sensor 2   temperature
rack-1    vec       d29e0bd113a484dc48fd55bd3abad6bb   Synse backup LED             led
rack-1    vec       db1e5deb43d9d0af6d80885e74362913   Synse Temperature Sensor 3   temperature
rack-1    vec       eb100067acb0c054cf877759db376b03   Synse Temperature Sensor 1   temperature
rack-1    vec       eb9a56f95b5bd6d9b51996ccd0f2329c   Synse Fan                    fan
rack-1    vec       f52d29fecf05a195af13f14c7306cfed   Synse LED                    led
rack-1    vec       f97f284037b04badb6bb7aacd9654a4e   Synse Temperature Sensor 5   temperature

edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (timestamp-formatting *) ➜ ./build/synse read rack-1 vec f52d29fecf05a195af13f14c7306cfed
TYPE      VALUE     TIMESTAMP
state     off       Thu Feb 15 14:19:02 UTC 2018
color     000000    Thu Feb 15 14:19:02 UTC 2018
blink     steady    Thu Feb 15 14:19:02 UTC 2018

edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (timestamp-formatting *) ➜ ./build/synse write rack-1 vec f52d29fecf05a195af13f14c7306cfed color ffffff
TRANSACTION ID         ACTION    RAW 
ba2peai2382g01pifi70   color     ffffff 

edaniszewski ~/go/src/github.com/vapor-ware/synse-cli (timestamp-formatting *) ➜ ./build/synse transaction ba2peai2382g01pifi70
STATUS    STATE     CREATED                        UPDATED
done      ok        Thu Feb 15 14:20:26 UTC 2018   Thu Feb 15 14:20:27 UTC 2018
```