### PR TITLE
add synse server 'plugins' command

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,9 @@ const (
 	// configBaseURI is the base URI for the 'config' route.
 	configBaseURI = "config"
 
+	// pluginsBaseURI is the base URI for the 'plugins' route.
+	pluginsBaseURI = "plugins"
+
 	// scanBaseURI is the base URI for the 'scan' route.
 	scanBaseURI = "scan"
 
@@ -193,6 +196,16 @@ func (c *synseClient) Version() (*scheme.Version, error) {
 func (c *synseClient) Config() (*scheme.Config, error) {
 	out := &scheme.Config{}
 	err := getVersioned(configBaseURI, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Plugins gets and parses the response from Synse Server's "plugins" endpoint.
+func (c *synseClient) Plugins() ([]scheme.Plugin, error) {
+	var out []scheme.Plugin
+	err := getVersioned(pluginsBaseURI, &out)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -15,6 +15,7 @@ var Commands = []cli.Command{
 	server.VersionCommand,
 	server.ScanCommand,
 	server.ConfigCommand,
+	server.PluginsCommand,
 	server.ReadCommand,
 	server.WriteCommand,
 	server.InfoCommand,

--- a/pkg/commands/server/config.go
+++ b/pkg/commands/server/config.go
@@ -42,7 +42,7 @@ var ConfigCommand = cli.Command{
 	},
 }
 
-// cmdConfig is the action for the ConfigCommand. It makes an "config" request
+// cmdConfig is the action for the ConfigCommand. It makes a "config" request
 // against the active Synse Server instance.
 func cmdConfig(c *cli.Context) error {
 	cfg, err := client.Client.Config()

--- a/pkg/commands/server/plugins.go
+++ b/pkg/commands/server/plugins.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+	"github.com/vapor-ware/synse-cli/pkg/client"
+	"github.com/vapor-ware/synse-cli/pkg/formatters"
+	"github.com/vapor-ware/synse-cli/pkg/utils"
+)
+
+const (
+	// pluginsCmdName is the name for the 'plugins' command.
+	pluginsCmdName = "plugins"
+
+	// pluginsCmdUsage is the usage text for the 'plugins' command.
+	pluginsCmdUsage = "Get a list of plugins that are configured with the active host"
+
+	// pluginsCmdDesc is the description for the 'plugins' command.
+	pluginsCmdDesc = `The plugins command hits the active Synse Server host's '/plugins'
+	 endpoint, which returns the current set of configured plugins for that
+	 instance.`
+)
+
+// PluginsCommand is the CLI command for Synse Server's "plugins" API route.
+var PluginsCommand = cli.Command{
+	Name:        pluginsCmdName,
+	Usage:       pluginsCmdUsage,
+	Description: pluginsCmdDesc,
+	Category:    SynseActionsCategory,
+	ArgsUsage:   utils.NoArgs,
+
+	Action: func(c *cli.Context) error {
+		return utils.CmdHandler(cmdPlugins(c))
+	},
+}
+
+// cmPlugins is the action for the PluginsCommand. It makes a "plugins" request
+// against the active Synse Server instance.
+func cmdPlugins(c *cli.Context) error {
+	plugins, err := client.Client.Plugins()
+	if err != nil {
+		return err
+	}
+
+	formatter := formatters.NewPluginsFormatter(c.App.Writer)
+	err = formatter.Add(plugins)
+	if err != nil {
+		return err
+	}
+	return formatter.Write()
+}

--- a/pkg/commands/server/plugins_test.go
+++ b/pkg/commands/server/plugins_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/vapor-ware/synse-cli/internal/test"
+)
+
+const pluginsRespOK = `
+[
+  {
+    "name": "foo",
+    "network": "tcp",
+    "address": "localhost:6000"
+  },
+  {
+    "name": "bar",
+    "network": "unix",
+    "address": "/tmp/synse/proc/bar.sock"
+  }
+]`
+
+func TestPluginsCommandError(t *testing.T) {
+	test.Setup()
+
+	mux, server := test.Server()
+	defer server.Close()
+	mux.HandleFunc(
+		"/synse/2.0/plugins",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+		},
+	)
+
+	test.AddServerHost(server)
+	app := test.NewFakeApp()
+	app.Commands = append(app.Commands, PluginsCommand)
+
+	err := app.Run([]string{app.Name, PluginsCommand.Name})
+
+	test.ExpectExitCoderError(t, err)
+}
+
+func TestPluginsCommandSuccess(t *testing.T) {
+	test.Setup()
+
+	mux, server := test.Server()
+	defer server.Close()
+	mux.HandleFunc(
+		"/synse/2.0/plugins",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, pluginsRespOK)
+		},
+	)
+
+	test.AddServerHost(server)
+	app := test.NewFakeApp()
+	app.Commands = append(app.Commands, PluginsCommand)
+
+	err := app.Run([]string{app.Name, PluginsCommand.Name})
+
+	test.ExpectNoError(t, err)
+}

--- a/pkg/commands/server/read.go
+++ b/pkg/commands/server/read.go
@@ -38,7 +38,7 @@ var ReadCommand = cli.Command{
 	BashComplete: completion.CompleteRackBoardDevice,
 }
 
-// cmdRead is the action for the ReadCommand. It makes an "read" request
+// cmdRead is the action for the ReadCommand. It makes a "read" request
 // against the active Synse Server instance.
 func cmdRead(c *cli.Context) error {
 	err := utils.RequiresArgsExact(3, c)

--- a/pkg/commands/server/scan.go
+++ b/pkg/commands/server/scan.go
@@ -74,7 +74,7 @@ func (s byScanDeviceID) Less(i, j int) bool {
 	return s[i].ID() < s[j].ID()
 }
 
-// cmdScan is the action for the ScanCommand. It makes an "scan" request
+// cmdScan is the action for the ScanCommand. It makes a "scan" request
 // against the active Synse Server instance.
 func cmdScan(c *cli.Context) error {
 	scan, err := client.Client.Scan()

--- a/pkg/commands/server/status.go
+++ b/pkg/commands/server/status.go
@@ -43,7 +43,7 @@ var StatusCommand = cli.Command{
 	},
 }
 
-// cmdStatus is the action for the StatusCommand. It makes an "status" request
+// cmdStatus is the action for the StatusCommand. It makes a "status" request
 // against the active Synse Server instance.
 func cmdStatus(c *cli.Context) error {
 	status, err := client.Client.Status()

--- a/pkg/commands/server/transaction.go
+++ b/pkg/commands/server/transaction.go
@@ -40,7 +40,7 @@ var TransactionCommand = cli.Command{
 	},
 }
 
-// cmdTransaction is the action for the TransactionCommand. It makes an "transaction"
+// cmdTransaction is the action for the TransactionCommand. It makes a "transaction"
 // request against the active Synse Server instance.
 func cmdTransaction(c *cli.Context) error {
 	err := utils.RequiresArgsExact(1, c)

--- a/pkg/commands/server/version.go
+++ b/pkg/commands/server/version.go
@@ -42,7 +42,7 @@ var VersionCommand = cli.Command{
 	},
 }
 
-// cmdVersion is the action for the VersionCommand. It makes an "version" request
+// cmdVersion is the action for the VersionCommand. It makes a "version" request
 // against the active Synse Server instance.
 func cmdVersion(c *cli.Context) error {
 	version, err := client.Client.Version()

--- a/pkg/commands/server/write.go
+++ b/pkg/commands/server/write.go
@@ -38,7 +38,7 @@ var WriteCommand = cli.Command{
 	BashComplete: completion.CompleteRackBoardDevice,
 }
 
-// cmdWrite is the action for the WriteCommand. It makes an "write" request
+// cmdWrite is the action for the WriteCommand. It makes a "write" request
 // against the active Synse Server instance.
 func cmdWrite(c *cli.Context) error {
 	err := utils.RequiresArgsInRange(4, 5, c)

--- a/pkg/formatters/plugins.go
+++ b/pkg/formatters/plugins.go
@@ -1,0 +1,55 @@
+package formatters
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vapor-ware/synse-cli/pkg/scheme"
+)
+
+const (
+	// the default output template for plugins requests
+	pluginsTmpl = "table {{.Name}}\t{{.Network}}\t{{.Address}}\n"
+)
+
+// pluginsFormat collects the data that will be parsed into the output template.
+type pluginsFormat struct {
+	Name    string
+	Network string
+	Address string
+}
+
+// newPluginsFormat is the handler for plugins commands that is used by the
+// Formatter to add new plugin data to the format context.
+func newPluginsFormat(data interface{}) (interface{}, error) {
+	plugins, ok := data.([]scheme.Plugin)
+	if !ok {
+		return nil, fmt.Errorf("formatter data %T not of type []scheme.Plugin", data)
+	}
+
+	var out []interface{}
+	for _, p := range plugins {
+		out = append(out, &pluginsFormat{
+			Name:    p.Name,
+			Network: p.Network,
+			Address: p.Address,
+		})
+	}
+	return out, nil
+}
+
+// NewPluginsFormatter creates a new instance of a Formatter configured
+// for the plugins command.
+func NewPluginsFormatter(out io.Writer) *Formatter {
+	f := NewFormatter(
+		pluginsTmpl,
+		out,
+	)
+	f.SetHandler(newPluginsFormat)
+	f.SetHeader(pluginsFormat{
+		Name:    "NAME",
+		Network: "NETWORK",
+		Address: "ADDRESS",
+	})
+	return f
+}

--- a/pkg/scheme/plugins.go
+++ b/pkg/scheme/plugins.go
@@ -1,0 +1,8 @@
+package scheme
+
+// Plugin is the scheme for the Synse Server "plugin" endpoint response.
+type Plugin struct {
+	Name    string `json:"name" yaml:"name"`
+	Network string `json:"network" yaml:"network"`
+	Address string `json:"address" yaml:"address"`
+}


### PR DESCRIPTION
adds support for the Synse Server "plugins" command which was recently added to Synse Server. This will list all of the plugins currently configured with Synse Server. 

fixes #110 