### PR TITLE
move server commands to a subcommand

### DIFF
--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -11,14 +11,6 @@ import (
 var Commands = []cli.Command{
 	hosts.HostsCommand,
 	plugin.PluginCommand,
-	server.StatusCommand,
-	server.VersionCommand,
-	server.ScanCommand,
-	server.ConfigCommand,
-	server.PluginsCommand,
-	server.ReadCommand,
-	server.WriteCommand,
-	server.InfoCommand,
-	server.TransactionCommand,
+	server.ServerCommand,
 	completionCommand,
 }

--- a/pkg/commands/server/cmd.go
+++ b/pkg/commands/server/cmd.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"github.com/urfave/cli"
+)
+
+// ServerCommand is the CLI command for interacting with Synse Server.
+var ServerCommand = cli.Command{
+	Name:  "server",
+	Usage: "Interact with Synse Server",
+
+	Subcommands: []cli.Command{
+		configCommand,
+		infoCommand,
+		pluginsCommand,
+		readCommand,
+		scanCommand,
+		statusCommand,
+		transactionCommand,
+		versionCommand,
+		writeCommand,
+	},
+}

--- a/pkg/commands/server/config.go
+++ b/pkg/commands/server/config.go
@@ -20,12 +20,11 @@ const (
 	 instance.`
 )
 
-// ConfigCommand is the CLI command for Synse Server's "config" API route.
-var ConfigCommand = cli.Command{
+// configCommand is the CLI command for Synse Server's "config" API route.
+var configCommand = cli.Command{
 	Name:        configCmdName,
 	Usage:       configCmdUsage,
 	Description: configCmdDesc,
-	Category:    SynseActionsCategory,
 	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
@@ -33,7 +32,7 @@ var ConfigCommand = cli.Command{
 	},
 }
 
-// cmdConfig is the action for the ConfigCommand. It makes a "config" request
+// cmdConfig is the action for the configCommand. It makes a "config" request
 // against the active Synse Server instance.
 func cmdConfig(c *cli.Context) error {
 	cfg, err := client.Client.Config()

--- a/pkg/commands/server/config_test.go
+++ b/pkg/commands/server/config_test.go
@@ -38,9 +38,9 @@ func TestConfigCommandError(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ConfigCommand)
+	app.Commands = append(app.Commands, configCommand)
 
-	err := app.Run([]string{app.Name, ConfigCommand.Name})
+	err := app.Run([]string{app.Name, configCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -57,9 +57,9 @@ func TestConfigCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ConfigCommand)
+	app.Commands = append(app.Commands, configCommand)
 
-	err := app.Run([]string{app.Name, ConfigCommand.Name})
+	err := app.Run([]string{app.Name, configCommand.Name})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/doc.go
+++ b/pkg/commands/server/doc.go
@@ -12,6 +12,3 @@ endpoints provided by Synse Server, namely:
  - /transaction/...
 */
 package server
-
-// SynseActionsCategory defines the category name for Synse Server actions.
-const SynseActionsCategory = "Synse Server Actions"

--- a/pkg/commands/server/info.go
+++ b/pkg/commands/server/info.go
@@ -21,12 +21,11 @@ const (
 	 rack level, the board level, or the device level.`
 )
 
-// InfoCommand is the CLI command for Synse Server's "info" API route.
-var InfoCommand = cli.Command{
+// infoCommand is the CLI command for Synse Server's "info" API route.
+var infoCommand = cli.Command{
 	Name:        infoCmdName,
 	Usage:       infoCmdUsage,
 	Description: infoCmdDesc,
-	Category:    SynseActionsCategory,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdInfo(c))
@@ -35,7 +34,7 @@ var InfoCommand = cli.Command{
 	BashComplete: completion.CompleteRackBoardDevice,
 }
 
-// cmdInfo is the action for the InfoCommand. It makes an "info" request
+// cmdInfo is the action for the infoCommand. It makes an "info" request
 // against the active Synse Server instance.
 func cmdInfo(c *cli.Context) (err error) {
 	err = utils.RequiresArgsInRange(1, 3, c)

--- a/pkg/commands/server/info_test.go
+++ b/pkg/commands/server/info_test.go
@@ -71,9 +71,9 @@ func TestInfoCommandError(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name})
+	err := app.Run([]string{app.Name, infoCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -82,9 +82,9 @@ func TestInfoCommandError2(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1", "board-1", "device-1", "extra"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1", "board-1", "device-1", "extra"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -104,9 +104,9 @@ func TestInfoCommandErrorRack(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -126,9 +126,9 @@ func TestInfoCommandSuccessRack(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1"})
 
 	test.ExpectNoError(t, err)
 }
@@ -148,9 +148,9 @@ func TestInfoCommandErrorBoard(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1", "board-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1", "board-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -170,9 +170,9 @@ func TestInfoCommandSuccessBoard(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1", "board-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1", "board-1"})
 
 	test.ExpectNoError(t, err)
 }
@@ -192,9 +192,9 @@ func TestInfoCommandErrorDevice(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1", "board-1", "device-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1", "board-1", "device-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -214,9 +214,9 @@ func TestInfoCommandSuccessDevice(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, InfoCommand)
+	app.Commands = append(app.Commands, infoCommand)
 
-	err := app.Run([]string{app.Name, InfoCommand.Name, "rack-1", "board-1", "device-1"})
+	err := app.Run([]string{app.Name, infoCommand.Name, "rack-1", "board-1", "device-1"})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/plugins.go
+++ b/pkg/commands/server/plugins.go
@@ -20,12 +20,11 @@ const (
 	 instance.`
 )
 
-// PluginsCommand is the CLI command for Synse Server's "plugins" API route.
-var PluginsCommand = cli.Command{
+// pluginsCommand is the CLI command for Synse Server's "plugins" API route.
+var pluginsCommand = cli.Command{
 	Name:        pluginsCmdName,
 	Usage:       pluginsCmdUsage,
 	Description: pluginsCmdDesc,
-	Category:    SynseActionsCategory,
 	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
@@ -33,7 +32,7 @@ var PluginsCommand = cli.Command{
 	},
 }
 
-// cmPlugins is the action for the PluginsCommand. It makes a "plugins" request
+// cmPlugins is the action for the pluginsCommand. It makes a "plugins" request
 // against the active Synse Server instance.
 func cmdPlugins(c *cli.Context) error {
 	plugins, err := client.Client.Plugins()

--- a/pkg/commands/server/plugins_test.go
+++ b/pkg/commands/server/plugins_test.go
@@ -37,9 +37,9 @@ func TestPluginsCommandError(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, PluginsCommand)
+	app.Commands = append(app.Commands, pluginsCommand)
 
-	err := app.Run([]string{app.Name, PluginsCommand.Name})
+	err := app.Run([]string{app.Name, pluginsCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -59,9 +59,9 @@ func TestPluginsCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, PluginsCommand)
+	app.Commands = append(app.Commands, pluginsCommand)
 
-	err := app.Run([]string{app.Name, PluginsCommand.Name})
+	err := app.Run([]string{app.Name, pluginsCommand.Name})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/read.go
+++ b/pkg/commands/server/read.go
@@ -24,12 +24,11 @@ const (
 	 the plugin level.`
 )
 
-// ReadCommand is the CLI command for Synse Server's "read" API route.
-var ReadCommand = cli.Command{
+// readCommand is the CLI command for Synse Server's "read" API route.
+var readCommand = cli.Command{
 	Name:        readCmdName,
 	Usage:       readCmdUsage,
 	Description: readCmdDesc,
-	Category:    SynseActionsCategory,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdRead(c))
@@ -38,7 +37,7 @@ var ReadCommand = cli.Command{
 	BashComplete: completion.CompleteRackBoardDevice,
 }
 
-// cmdRead is the action for the ReadCommand. It makes a "read" request
+// cmdRead is the action for the readCommand. It makes a "read" request
 // against the active Synse Server instance.
 func cmdRead(c *cli.Context) error {
 	err := utils.RequiresArgsExact(3, c)

--- a/pkg/commands/server/read_test.go
+++ b/pkg/commands/server/read_test.go
@@ -27,9 +27,9 @@ func TestReadCommandError(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ReadCommand)
+	app.Commands = append(app.Commands, readCommand)
 
-	err := app.Run([]string{app.Name, ReadCommand.Name, "rack-1", "board-1"})
+	err := app.Run([]string{app.Name, readCommand.Name, "rack-1", "board-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -38,9 +38,9 @@ func TestReadCommandError2(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ReadCommand)
+	app.Commands = append(app.Commands, readCommand)
 
-	err := app.Run([]string{app.Name, ReadCommand.Name, "rack-1", "board-1", "device-1", "extra"})
+	err := app.Run([]string{app.Name, readCommand.Name, "rack-1", "board-1", "device-1", "extra"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -60,9 +60,9 @@ func TestReadCommandError3(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ReadCommand)
+	app.Commands = append(app.Commands, readCommand)
 
-	err := app.Run([]string{app.Name, ReadCommand.Name, "rack-1", "board-1", "device-1"})
+	err := app.Run([]string{app.Name, readCommand.Name, "rack-1", "board-1", "device-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -82,9 +82,9 @@ func TestReadCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ReadCommand)
+	app.Commands = append(app.Commands, readCommand)
 
-	err := app.Run([]string{app.Name, ReadCommand.Name, "rack-1", "board-1", "device-1"})
+	err := app.Run([]string{app.Name, readCommand.Name, "rack-1", "board-1", "device-1"})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/scan.go
+++ b/pkg/commands/server/scan.go
@@ -21,12 +21,11 @@ const (
 	 Server via the instance's configured plugins.`
 )
 
-// ScanCommand is the CLI command for Synse Server's "scan" API route.
-var ScanCommand = cli.Command{
+// scanCommand is the CLI command for Synse Server's "scan" API route.
+var scanCommand = cli.Command{
 	Name:        scanCmdName,
 	Usage:       scanCmdUsage,
 	Description: scanCmdDesc,
-	Category:    SynseActionsCategory,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdScan(c))
@@ -48,7 +47,7 @@ var ScanCommand = cli.Command{
 	},
 }
 
-// cmdScan is the action for the ScanCommand. It makes a "scan" request
+// cmdScan is the action for the scanCommand. It makes a "scan" request
 // against the active Synse Server instance.
 func cmdScan(c *cli.Context) error {
 	scan, err := client.Client.Scan()

--- a/pkg/commands/server/scan_test.go
+++ b/pkg/commands/server/scan_test.go
@@ -79,9 +79,9 @@ func TestScanCommandError(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ScanCommand)
+	app.Commands = append(app.Commands, scanCommand)
 
-	err := app.Run([]string{app.Name, ScanCommand.Name})
+	err := app.Run([]string{app.Name, scanCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -101,9 +101,9 @@ func TestScanCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, ScanCommand)
+	app.Commands = append(app.Commands, scanCommand)
 
-	err := app.Run([]string{app.Name, ScanCommand.Name})
+	err := app.Run([]string{app.Name, scanCommand.Name})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/status.go
+++ b/pkg/commands/server/status.go
@@ -21,12 +21,11 @@ const (
 	 is an error either with Synse Server or connecting to it.`
 )
 
-// StatusCommand is the CLI command for Synse Server's "test" API route.
-var StatusCommand = cli.Command{
+// statusCommand is the CLI command for Synse Server's "test" API route.
+var statusCommand = cli.Command{
 	Name:        testCmdName,
 	Usage:       testCmdUsage,
 	Description: testCmdDesc,
-	Category:    SynseActionsCategory,
 	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
@@ -34,7 +33,7 @@ var StatusCommand = cli.Command{
 	},
 }
 
-// cmdStatus is the action for the StatusCommand. It makes a "status" request
+// cmdStatus is the action for the statusCommand. It makes a "status" request
 // against the active Synse Server instance.
 func cmdStatus(c *cli.Context) error {
 	status, err := client.Client.Status()

--- a/pkg/commands/server/status_test.go
+++ b/pkg/commands/server/status_test.go
@@ -26,9 +26,9 @@ func TestStatusCommandError(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, StatusCommand)
+	app.Commands = append(app.Commands, statusCommand)
 
-	err := app.Run([]string{app.Name, StatusCommand.Name})
+	err := app.Run([]string{app.Name, statusCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -45,9 +45,9 @@ func TestStatusCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, StatusCommand)
+	app.Commands = append(app.Commands, statusCommand)
 
-	err := app.Run([]string{app.Name, StatusCommand.Name})
+	err := app.Run([]string{app.Name, statusCommand.Name})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/transaction.go
+++ b/pkg/commands/server/transaction.go
@@ -19,19 +19,18 @@ const (
 	 endpoint, which returns the state and status of the specified transaction.`
 )
 
-// TransactionCommand is the CLI command for Synse Server's "transaction" API route.
-var TransactionCommand = cli.Command{
+// transactionCommand is the CLI command for Synse Server's "transaction" API route.
+var transactionCommand = cli.Command{
 	Name:        transactionCmdName,
 	Usage:       transactionCmdUsage,
 	Description: transactionCmdDesc,
-	Category:    SynseActionsCategory,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdTransaction(c))
 	},
 }
 
-// cmdTransaction is the action for the TransactionCommand. It makes a "transaction"
+// cmdTransaction is the action for the transactionCommand. It makes a "transaction"
 // request against the active Synse Server instance.
 func cmdTransaction(c *cli.Context) error {
 	err := utils.RequiresArgsExact(1, c)

--- a/pkg/commands/server/transaction_test.go
+++ b/pkg/commands/server/transaction_test.go
@@ -28,9 +28,9 @@ func TestTransactionCommandError(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, TransactionCommand)
+	app.Commands = append(app.Commands, transactionCommand)
 
-	err := app.Run([]string{app.Name, TransactionCommand.Name})
+	err := app.Run([]string{app.Name, transactionCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -50,9 +50,9 @@ func TestTransactionCommandError2(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, TransactionCommand)
+	app.Commands = append(app.Commands, transactionCommand)
 
-	err := app.Run([]string{app.Name, TransactionCommand.Name, "b9u6ss6q5i6g020lau6g"})
+	err := app.Run([]string{app.Name, transactionCommand.Name, "b9u6ss6q5i6g020lau6g"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -72,9 +72,9 @@ func TestTransactionCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, TransactionCommand)
+	app.Commands = append(app.Commands, transactionCommand)
 
-	err := app.Run([]string{app.Name, TransactionCommand.Name, "b9u6ss6q5i6g020lau6g"})
+	err := app.Run([]string{app.Name, transactionCommand.Name, "b9u6ss6q5i6g020lau6g"})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/version.go
+++ b/pkg/commands/server/version.go
@@ -20,12 +20,11 @@ const (
 	 Server instance.`
 )
 
-// VersionCommand is the CLI command for Synse Server's "version" API route.
-var VersionCommand = cli.Command{
+// versionCommand is the CLI command for Synse Server's "version" API route.
+var versionCommand = cli.Command{
 	Name:        versionCmdName,
 	Usage:       versionCmdUsage,
 	Description: versionCmdDesc,
-	Category:    SynseActionsCategory,
 	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
@@ -33,7 +32,7 @@ var VersionCommand = cli.Command{
 	},
 }
 
-// cmdVersion is the action for the VersionCommand. It makes a "version" request
+// cmdVersion is the action for the versionCommand. It makes a "version" request
 // against the active Synse Server instance.
 func cmdVersion(c *cli.Context) error {
 	version, err := client.Client.Version()

--- a/pkg/commands/server/version_test.go
+++ b/pkg/commands/server/version_test.go
@@ -26,9 +26,9 @@ func TestVersionCommandError(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, VersionCommand)
+	app.Commands = append(app.Commands, versionCommand)
 
-	err := app.Run([]string{app.Name, VersionCommand.Name})
+	err := app.Run([]string{app.Name, versionCommand.Name})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -45,9 +45,9 @@ func TestVersionCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, VersionCommand)
+	app.Commands = append(app.Commands, versionCommand)
 
-	err := app.Run([]string{app.Name, VersionCommand.Name})
+	err := app.Run([]string{app.Name, versionCommand.Name})
 
 	test.ExpectNoError(t, err)
 }

--- a/pkg/commands/server/write.go
+++ b/pkg/commands/server/write.go
@@ -24,12 +24,11 @@ const (
 	 the plugin level.`
 )
 
-// WriteCommand is the CLI command for Synse Server's "write" API route.
-var WriteCommand = cli.Command{
+// writeCommand is the CLI command for Synse Server's "write" API route.
+var writeCommand = cli.Command{
 	Name:        writeCmdName,
 	Usage:       writeCmdUsage,
 	Description: writeCmdDesc,
-	Category:    SynseActionsCategory,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdWrite(c))
@@ -38,7 +37,7 @@ var WriteCommand = cli.Command{
 	BashComplete: completion.CompleteRackBoardDevice,
 }
 
-// cmdWrite is the action for the WriteCommand. It makes a "write" request
+// cmdWrite is the action for the writeCommand. It makes a "write" request
 // against the active Synse Server instance.
 func cmdWrite(c *cli.Context) error {
 	err := utils.RequiresArgsInRange(4, 5, c)

--- a/pkg/commands/server/write_test.go
+++ b/pkg/commands/server/write_test.go
@@ -25,9 +25,9 @@ func TestWriteCommandError(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, WriteCommand)
+	app.Commands = append(app.Commands, writeCommand)
 
-	err := app.Run([]string{app.Name, WriteCommand.Name, "rack-1", "board-1", "device-1"})
+	err := app.Run([]string{app.Name, writeCommand.Name, "rack-1", "board-1", "device-1"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -36,9 +36,9 @@ func TestWriteCommandError2(t *testing.T) {
 	test.Setup()
 
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, WriteCommand)
+	app.Commands = append(app.Commands, writeCommand)
 
-	err := app.Run([]string{app.Name, WriteCommand.Name, "rack-1", "board-1", "device-1", "color", "000000", "extra"})
+	err := app.Run([]string{app.Name, writeCommand.Name, "rack-1", "board-1", "device-1", "color", "000000", "extra"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -58,9 +58,9 @@ func TestWriteCommandError3(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, WriteCommand)
+	app.Commands = append(app.Commands, writeCommand)
 
-	err := app.Run([]string{app.Name, WriteCommand.Name, "rack-1", "board-1", "device-1", "color", "000000"})
+	err := app.Run([]string{app.Name, writeCommand.Name, "rack-1", "board-1", "device-1", "color", "000000"})
 
 	test.ExpectExitCoderError(t, err)
 }
@@ -84,9 +84,9 @@ func TestWriteCommandSuccess(t *testing.T) {
 
 	test.AddServerHost(server)
 	app := test.NewFakeApp()
-	app.Commands = append(app.Commands, WriteCommand)
+	app.Commands = append(app.Commands, writeCommand)
 
-	err := app.Run([]string{app.Name, WriteCommand.Name, "rack-1", "board-1", "device-1", "color", "000000"})
+	err := app.Run([]string{app.Name, writeCommand.Name, "rack-1", "board-1", "device-1", "color", "000000"})
 
 	test.ExpectNoError(t, err)
 }


### PR DESCRIPTION
fixes #127 

```
➜ ./build/synse 
NAME:
   synse - Command line tool for interacting with Synse components

USAGE:
   synse [global options] command [command options] [arguments...]

VERSION:
   0.1.0

COMMANDS:
     hosts       Manage Synse Server instances
     plugin      Interact with Synse Plugins
     server      Interact with Synse Server
     completion  Generate shell completion scripts for bash or zsh
     help, h     Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug, -d     enable debug mode
   --config        display the current CLI configuration
   --format value  specify the output format for a command (default: "pretty")
   --help, -h      show help
   --version, -v   print the version
```

```
➜ ./build/synse server
NAME:
   synse server - Interact with Synse Server

USAGE:
   synse server command [command options] [arguments...]

COMMANDS:
     config       Get the configuration for the active host
     info         Get info for the specified rack, board, or device
     plugins      Get a list of plugins that are configured with the active host
     read         Read from the specified device
     scan         Enumerate all devices on the active host
     status       Get the status of the active host
     transaction  Check the state and status of a transaction
     version      Get the version of the active host
     write        Write to the specified device

OPTIONS:
   --help, -h  show help

```