### PR TITLE
add/improve help text for commands

### DIFF
--- a/cmd/synse.go
+++ b/cmd/synse.go
@@ -84,6 +84,55 @@ func main() {
 		flags.FormatFlag, // --format flag to specify the output format for a command
 	}
 
+	cli.AppHelpTemplate = `
+{{.Usage}}
+
+Usage:
+  {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} COMMAND [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}
+{{if .Commands}}
+Commands:
+{{range .Commands}}{{if not .HideHelp}}  {{join .Names ", "}}{{ "\t"}}{{.Usage}}{{ "\n" }}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
+Global Options:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}{{end}}
+Use 'synse COMMAND --help' for more information on a command.
+`
+
+	cli.CommandHelpTemplate = `
+{{.Usage}}
+
+Usage:
+  {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+
+Category:
+  {{.Category}}{{end}}{{if .Description}}
+
+Description:
+  {{.Description}}{{end}}{{if .VisibleFlags}}
+
+Options:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}{{end}}
+`
+
+	cli.SubcommandHelpTemplate = `
+{{.Usage}}{{if .Description}}
+
+Description:
+  {{.Description}}{{end}}
+
+Usage:
+  {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
+
+Commands:{{range .VisibleCategories}}{{if .Name}}
+  {{.Name}}:{{end}}{{range .VisibleCommands}}
+  {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}
+{{end}}{{if .VisibleFlags}}
+Options:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}{{end}}
+`
+
 	// Run the CLI
 	err := app.Run(os.Args)
 	if err != nil {

--- a/pkg/commands/hosts/active.go
+++ b/pkg/commands/hosts/active.go
@@ -7,10 +7,34 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// activeCmdName is the name for the 'active' command.
+	activeCmdName = "active"
+
+	// activeCmdUsage is the usage text for the 'active' command.
+	activeCmdUsage = "Show the active host"
+
+	// activeCmdDesc is the description for the 'active' command.
+	activeCmdDesc = `The active command shows information on which Synse Server
+  host is currently active. An 'active host' is the instance
+  that all 'synse server' commands will be routed to.
+
+Example:
+  synse hosts active
+
+Formatting:
+  The 'hosts active' command supports the following formatting
+  options (via the CLI global --format flag):
+    - yaml (default)
+    - json`
+)
+
 // hostsActiveCommand is the CLI sub-command for getting the active host.
 var hostsActiveCommand = cli.Command{
-	Name:  "active",
-	Usage: "Display information for the active host",
+	Name:        activeCmdName,
+	Usage:       activeCmdUsage,
+	Description: activeCmdDesc,
+	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdActive(c))

--- a/pkg/commands/hosts/add.go
+++ b/pkg/commands/hosts/add.go
@@ -6,11 +6,31 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// addCmdName is the name for the 'add' command.
+	addCmdName = "add"
+
+	// addCmdUsage is the usage text for the 'add' command.
+	addCmdUsage = "Add a new Synse Server host"
+
+	// addCmdArgsUsage is the argument usage for the 'add' command.
+	addCmdArgsUsage = "NAME HOST"
+
+	// addCmdDesc is the description for the 'add' command.
+	addCmdDesc = `The add command adds a new Synse Server instance to the
+  available hosts that the CLI can interface with.
+
+Example:
+  synse hosts add local localhost:5000`
+)
+
 // hostsAddCommand is the CLI sub-command for adding a new host to the CLI
 // configuration.
 var hostsAddCommand = cli.Command{
-	Name:  "add",
-	Usage: "Add a new Synse Server host",
+	Name:        addCmdName,
+	Usage:       addCmdUsage,
+	Description: addCmdDesc,
+	ArgsUsage:   addCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdAdd(c))

--- a/pkg/commands/hosts/change.go
+++ b/pkg/commands/hosts/change.go
@@ -9,10 +9,31 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// changeCmdName is the name for the 'change' command.
+	changeCmdName = "change"
+
+	// changeCmdUsage is the usage text for the 'change' command.
+	changeCmdUsage = "Change the active host"
+
+	// changeCmdArgsUsage is the argument usage for the 'change' command.
+	changemdArgsUsage = "NAME"
+
+	// changeCmdDesc is the description for the 'change' command.
+	changeCmdDesc = `The change command changes the active host to the one specified
+  by the given reference name. To see a list of all hosts that
+  are currently configured with the CLI, use 'synse hosts list'.
+
+Example:
+  synse hosts change local`
+)
+
 // hostsChangeCommand is the CLI sub-command for changing the active host.
 var hostsChangeCommand = cli.Command{
-	Name:  "change",
-	Usage: "Change the active host",
+	Name:        changeCmdName,
+	Usage:       changeCmdUsage,
+	Description: changeCmdDesc,
+	ArgsUsage:   changemdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdChange(c))

--- a/pkg/commands/hosts/cmd.go
+++ b/pkg/commands/hosts/cmd.go
@@ -4,10 +4,21 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	cmdName = "hosts"
+
+	cmdUsage = "Manage Synse Server instances"
+
+	cmdDescription = `This sub-command allows you to add, remove, change, and
+  enumerate Synse Server instance that can be interfaced with
+  for 'synse server' commands.`
+)
+
 // HostsCommand is the CLI command for managing Synse Server hosts.
 var HostsCommand = cli.Command{
-	Name:  "hosts",
-	Usage: "Manage Synse Server instances",
+	Name:        cmdName,
+	Usage:       cmdUsage,
+	Description: cmdDescription,
 
 	Subcommands: []cli.Command{
 		hostsActiveCommand,

--- a/pkg/commands/hosts/delete.go
+++ b/pkg/commands/hosts/delete.go
@@ -7,11 +7,31 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// deleteCmdName is the name for the 'delete' command.
+	deleteCmdName = "delete"
+
+	// deleteCmdUsage is the usage text for the 'delete' command.
+	deleteCmdUsage = "Delete a Synse Server host"
+
+	// deleteCmdArgsUsage is the argument usage for the 'delete' command.
+	deleteCmdArgsUsage = "NAME"
+
+	// deleteCmdDesc is the description for the 'delete' command.
+	deleteCmdDesc = `The delete command removes a Synse Server instance from the
+  tracked hosts configuration.
+
+Example:
+  synse hosts delete local`
+)
+
 // hostsDeleteCommand is the CLI sub-command for deleting a host from the
 // CLI configuration.
 var hostsDeleteCommand = cli.Command{
-	Name:  "delete",
-	Usage: "Delete a Synse Server host from configuration",
+	Name:        deleteCmdName,
+	Usage:       deleteCmdUsage,
+	Description: deleteCmdDesc,
+	ArgsUsage:   deleteCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdDelete(c))

--- a/pkg/commands/hosts/list.go
+++ b/pkg/commands/hosts/list.go
@@ -9,10 +9,34 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// listCmdName is the name for the 'list' command.
+	listCmdName = "list"
+
+	// listCmdUsage is the usage text for the 'list' command.
+	listCmdUsage = "List all configured Synse Server hosts"
+
+	// activeCmdDesc is the description for the 'list' command.
+	listCmdDesc = `The list command shows all of the Synse Server instances
+  that are currently configured with the CLI. The current
+  active host will be denoted with a '*', if there is an
+  active host.
+
+Example:
+  synse hosts list
+
+Formatting:
+  The 'hosts list' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
+)
+
 // hostsListCommand is the CLI sub-command for listing all configured hosts.
 var hostsListCommand = cli.Command{
-	Name:  "list",
-	Usage: "List the configured Synse Server hosts",
+	Name:        listCmdName,
+	Usage:       listCmdUsage,
+	Description: listCmdDesc,
+	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdList(c))

--- a/pkg/commands/plugin/cmd.go
+++ b/pkg/commands/plugin/cmd.go
@@ -4,10 +4,25 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	cmdName = "plugin"
+
+	cmdUsage = "Interact with Synse Plugins"
+
+	cmdDescription = `This sub-command allows you to interact with any Synse
+  Plugin instance. It uses the Synse gRPC API to make requests
+  directly to the Plugin itself. This does not depend on Synse
+  Server, so it can be useful for debugging plugins themselves.
+
+  One of the '--tcp' or '--unix' flags must be specified for
+  the CLI to know how to interface with the Plugin.`
+)
+
 // PluginCommand is the CLI command for interacting with Synse plugins.
 var PluginCommand = cli.Command{
-	Name:  "plugin",
-	Usage: "Interact with Synse Plugins",
+	Name:        cmdName,
+	Usage:       cmdUsage,
+	Description: cmdDescription,
 
 	Subcommands: []cli.Command{
 		pluginMetainfoCommand,

--- a/pkg/commands/plugin/metainfo.go
+++ b/pkg/commands/plugin/metainfo.go
@@ -7,10 +7,36 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// metainfoCmdName is the name for the 'metainfo' command.
+	metainfoCmdName = "meta"
+
+	// metainfoCmdUsage is the usage text for the 'metainfo' command.
+	metainfoCmdUsage = "Get meta information from a plugin"
+
+	// metainfoCmdDesc is the description for the 'metainfo' command.
+	metainfoCmdDesc = `The meta command gets meta information from a plugin via the
+  Synse gRPC API. The plugin meta info return is similar to that
+  of a 'synse server scan' command, but contains more information
+  about the device.
+
+  The 'plugin meta' command takes no arguments.
+
+Example:
+  synse plugin meta
+
+Formatting:
+  The 'plugin meta' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
+)
+
 // pluginMetainfoCommand is a CLI sub-command for getting metainfo from a plugin.
 var pluginMetainfoCommand = cli.Command{
-	Name:  "meta",
-	Usage: "Get the metainformation from a plugin",
+	Name:        metainfoCmdName,
+	Usage:       metainfoCmdUsage,
+	Description: metainfoCmdDesc,
+	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdMeta(c))

--- a/pkg/commands/plugin/read.go
+++ b/pkg/commands/plugin/read.go
@@ -9,10 +9,41 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// readCmdName is the name for the 'read' command.
+	readCmdName = "read"
+
+	// readCmdUsage is the usage text for the 'read' command.
+	readCmdUsage = "Get a reading from a plugin"
+
+	// readCmdArgsUsage is the argument usage for the 'read' command.
+	readCmdArgsUsage = "RACK BOARD DEVICE"
+
+	// readCmdDesc is the description for the 'read' command.
+	readCmdDesc = `The read command gets a device reading from a plugin via the
+  Synse gRPC API. The plugin read info return is similar to that
+  of a 'synse server read' command, and the response data for
+  both should look the same.
+
+  Reads require the rack, board, and device to be specified.
+  These can be found using the 'plugin meta' command, or with
+  tab completion, if enabled.
+
+Example:
+  synse plugin read rack-1 board 29d1a03e8cddfbf1cf68e14e60e5f5cc
+
+Formatting:
+  The 'plugin read' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
+)
+
 // pluginReadCommand is a CLI sub-command for getting a reading from a plugin.
 var pluginReadCommand = cli.Command{
-	Name:  "read",
-	Usage: "Get a reading from a plugin",
+	Name:        readCmdName,
+	Usage:       readCmdUsage,
+	Description: readCmdDesc,
+	ArgsUsage:   readCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdRead(c))

--- a/pkg/commands/plugin/transaction.go
+++ b/pkg/commands/plugin/transaction.go
@@ -8,10 +8,48 @@ import (
 	"github.com/vapor-ware/synse-cli/pkg/utils"
 )
 
+const (
+	// transactionCmdName is the name for the 'transaction' command.
+	transactionCmdName = "transaction"
+
+	// transactionCmdUsage is the usage text for the 'transaction' command.
+	transactionCmdUsage = "Get transaction info from a plugin"
+
+	// transactionCmdArgsUsage is the argument usage for the 'transaction' command.
+	transactionCmdArgsUsage = "TRANSACTION_ID"
+
+	// transactionCmdDesc is the description for the 'transaction' command.
+	transactionCmdDesc = `The transaction command gets the state and status of a
+  write via the Synse gRPC API.
+
+  Writes for Synse Plugins are asynchronous, so to verify
+  that a write has completed successfully, you must check
+  the state of the transaction afterwards.
+
+  The possible transaction states and statuses are:
+
+  STATUS        STATE
+  ----------    ----------
+  unknown       ok
+  pending       error
+  writing
+  done
+
+Example:
+  synse plugin transaction bah8volrogrg01o4sjtg
+
+Formatting:
+  The 'plugin transaction' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
+)
+
 // pluginTransactionCommand is a CLI sub-command for getting transaction info from a plugin.
 var pluginTransactionCommand = cli.Command{
-	Name:  "transaction",
-	Usage: "Get transaction info from a plugin",
+	Name:        transactionCmdName,
+	Usage:       transactionCmdUsage,
+	Description: transactionCmdDesc,
+	ArgsUsage:   transactionCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdTransaction(c))

--- a/pkg/commands/plugin/write.go
+++ b/pkg/commands/plugin/write.go
@@ -10,10 +10,59 @@ import (
 	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
+const (
+	// writeCmdName is the name for the 'write' command.
+	writeCmdName = "write"
+
+	// writeCmdUsage is the usage text for the 'write' command.
+	writeCmdUsage = "Write data to a plugin's device"
+
+	// writeCmdArgsUsage is the argument usage for the 'write' command.
+	writeCmdArgsUsage = "RACK BOARD DEVICE ACTION [DATA]"
+
+	// writeCmdDesc is the description for the 'write' command.
+	writeCmdDesc = `The write command writes data to a plugin's device via the
+  Synse gRPC API. The plugin write info return is similar to that
+  of a 'synse server write' command, and the response data for
+  both should look the same.
+
+  Writes to plugins are asynchronous, just as they are for
+  Synse Server, so this command will return a transaction ID
+  whose state/status can be checked with the 'plugin transaction'
+  command.
+
+  When writing to a device, the rack, board, and device id must be
+  specified along with the stuff to write. This 'stuff' is composed
+  of two parts -- the ACTION (e.g. the thing to change) and the
+  DATA (e.g. the value to change it to). Most devices require both
+  ACTION and DATA for writing, but some may require only an ACTION.
+
+  Below is a table listing some common actions and the requirements
+  for their data
+
+  TYPE      ACTION    DATA
+  --------  --------  -------------------
+  led       state     (on|off)
+            blink     (blink|steady)
+            color     RBG HEX string
+
+  fan       speed     integer
+
+Example:
+  synse plugin write rack-1 board 29d1a03e8cddfbf1cf68e14e60e5f5cc color ff00ff
+
+Formatting:
+  The 'plugin write' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
+)
+
 // pluginWriteCommand is a CLI sub-command for writing to a plugin
 var pluginWriteCommand = cli.Command{
-	Name:  "write",
-	Usage: "Write data directly to a plugin",
+	Name:        writeCmdName,
+	Usage:       writeCmdUsage,
+	Description: writeCmdDesc,
+	ArgsUsage:   writeCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdWrite(c))

--- a/pkg/commands/server/cmd.go
+++ b/pkg/commands/server/cmd.go
@@ -4,10 +4,21 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	cmdName = "server"
+
+	cmdUsage = "Interact with Synse Server"
+
+	cmdDescription = `This sub-command allows you to interact with a Synse Server
+  instance. The instance that is being interfaced with is set
+  and managed by the 'synse hosts' commands.`
+)
+
 // ServerCommand is the CLI command for interacting with Synse Server.
 var ServerCommand = cli.Command{
-	Name:  "server",
-	Usage: "Interact with Synse Server",
+	Name:        cmdName,
+	Usage:       cmdUsage,
+	Description: cmdDescription,
 
 	Subcommands: []cli.Command{
 		configCommand,

--- a/pkg/commands/server/config.go
+++ b/pkg/commands/server/config.go
@@ -12,12 +12,23 @@ const (
 	configCmdName = "config"
 
 	// configCmdUsage is the usage text for the 'config' command.
-	configCmdUsage = "Get the configuration for the active host"
+	configCmdUsage = "Get the Synse Server configuration"
 
 	// configCmdDesc is the description for the 'config' command.
 	configCmdDesc = `The config command hits the active Synse Server host's '/config'
-	 endpoint, which returns the current active configuration for that
-	 instance.`
+  endpoint, which returns the current active configuration for that
+  instance.
+
+  The 'server config' command takes no arguments.
+
+Example:
+  synse server config
+
+Formatting:
+  The 'server config' command supports the following formatting
+  options (via the CLI global --format flag):
+    - yaml (default)
+    - json`
 )
 
 // configCommand is the CLI command for Synse Server's "config" API route.

--- a/pkg/commands/server/info.go
+++ b/pkg/commands/server/info.go
@@ -15,10 +15,31 @@ const (
 	// infoCmdUsage is the usage text for the 'info' command.
 	infoCmdUsage = "Get info for the specified rack, board, or device"
 
+	// infoCmdArgsUsage is the argument usage for the 'info' command.
+	infoCmdArgsUsage = "RACK [BOARD [DEVICE]]"
+
 	// infoCmdDesc is the description for the 'info' command.
 	infoCmdDesc = `The info command hits the active Synse Server host's '/info'
-	 endpoint. Information can be provided at various scopes: the
-	 rack level, the board level, or the device level.`
+  endpoint. Information can be provided at various scopes: the
+  rack level, the board level, or the device level. Each level
+  of info will provide locational information (e.g. what lives
+  on it/what it lives on) as well as any entity-specific info.
+
+Example:
+  # rack level info request
+  synse rack-1
+
+  # board level info request
+  synse rack-1 board
+
+  # device level info request
+  synse rack-1 board 29d1a03e8cddfbf1cf68e14e60e5f5cc
+
+Formatting:
+  The 'server info' command supports the following formatting
+  options (via the CLI global --format flag):
+    - yaml (default)
+    - json`
 )
 
 // infoCommand is the CLI command for Synse Server's "info" API route.
@@ -26,6 +47,7 @@ var infoCommand = cli.Command{
 	Name:        infoCmdName,
 	Usage:       infoCmdUsage,
 	Description: infoCmdDesc,
+	ArgsUsage:   infoCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdInfo(c))

--- a/pkg/commands/server/plugins.go
+++ b/pkg/commands/server/plugins.go
@@ -12,12 +12,20 @@ const (
 	pluginsCmdName = "plugins"
 
 	// pluginsCmdUsage is the usage text for the 'plugins' command.
-	pluginsCmdUsage = "Get a list of plugins that are configured with the active host"
+	pluginsCmdUsage = "Get the list of plugins that are configured with Synse Server"
 
 	// pluginsCmdDesc is the description for the 'plugins' command.
 	pluginsCmdDesc = `The plugins command hits the active Synse Server host's '/plugins'
-	 endpoint, which returns the current set of configured plugins for that
-	 instance.`
+  endpoint, which returns the current set of configured plugins for
+  that instance.
+
+Example:
+  synse server plugins
+
+Formatting:
+  The 'server plugins' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
 )
 
 // pluginsCommand is the CLI command for Synse Server's "plugins" API route.

--- a/pkg/commands/server/read.go
+++ b/pkg/commands/server/read.go
@@ -15,13 +15,28 @@ const (
 	// readCmdUsage is the usage text for the 'read' command.
 	readCmdUsage = "Read from the specified device"
 
+	// readCmdArgsUsage is the argument usage for the 'read' command.
+	readCmdArgsUsage = "RACK BOARD DEVICE"
+
 	// readCmdDesc is the description for the 'read' command.
 	readCmdDesc = `The read command hits the active Synse Server host's '/read'
-	 endpoint to read from the specified device. A Synse Server read
-	 will be passed along to the backend plugin which handles the
-	 given device to get the reading information. Not all devices
-	 may support reading; device support for read is specified at
-	 the plugin level.`
+  endpoint to read from the specified device. A Synse Server read
+  will be passed along to the backend plugin which handles the
+  given device to get the reading information. Not all devices
+  may support reading; device support for read is specified at
+  the plugin level.
+
+  Reads require the rack, board, and device to be specified.
+  These can be found using the 'server scan' command, or with
+  tab completion, if enabled.
+
+Example:
+  synse read rack-1 board 29d1a03e8cddfbf1cf68e14e60e5f5cc
+
+Formatting:
+  The 'server read' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
 )
 
 // readCommand is the CLI command for Synse Server's "read" API route.
@@ -29,6 +44,7 @@ var readCommand = cli.Command{
 	Name:        readCmdName,
 	Usage:       readCmdUsage,
 	Description: readCmdDesc,
+	ArgsUsage:   readCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdRead(c))

--- a/pkg/commands/server/scan.go
+++ b/pkg/commands/server/scan.go
@@ -17,8 +17,42 @@ const (
 
 	// scanCmdDesc is the description for the 'scan' command.
 	scanCmdDesc = `The scan command hits the active Synse Server host's '/scan'
-	 endpoint, which enumerates all devices that are known to Synse
-	 Server via the instance's configured plugins.`
+  endpoint, which enumerates all devices that are known to Synse
+  Server via the instance's configured plugins.
+
+  The scan results can be sorted and filtered, which can be
+  useful when there are many devices managed by Synse Server.
+
+  Sorting is done via the '--sort' flag. The value for the flag
+  specified the fields that should be sorted. Multiple fields
+  can be specified by a comma separated string, e.g. "rack,board".
+  The first field will be the primary sort key, the second field
+  is the secondary sort key, etc. Currently, the fields that are
+  supported for sorting are:
+    * rack        * device
+    * board       * type
+
+  Filtering is done via the '--filter' flag. The value for the
+  flag is a string in the format "KEY=VALUE", where KEY is the
+  field to filter by, and VALUE is the desired value for that
+  field. Multiple filters can be set; see below for an example.
+  Currently, the fields that are supported for filtering are:
+    * rack        * type
+    * board
+
+Example:
+  # perform a scan and show only LED devices sorted by their
+  # rack, board, and device ids
+  synse server scan --sort "rack,board,device" --filter "type=led"
+
+  # perform a scan and show only temperature and pressure
+  # devices
+  synse server scan --filter "type=temperature" --filter "type=pressure"
+
+Formatting:
+  The 'server scan' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
 )
 
 // scanCommand is the CLI command for Synse Server's "scan" API route.
@@ -26,6 +60,7 @@ var scanCommand = cli.Command{
 	Name:        scanCmdName,
 	Usage:       scanCmdUsage,
 	Description: scanCmdDesc,
+	ArgsUsage:   utils.NoArgs,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdScan(c))

--- a/pkg/commands/server/status.go
+++ b/pkg/commands/server/status.go
@@ -12,13 +12,24 @@ const (
 	testCmdName = "status"
 
 	// testCmdUsage is the usage text for the 'status' command.
-	testCmdUsage = "Get the status of the active host"
+	testCmdUsage = "Get the status of Synse Server"
 
 	// testCmdDesc is the description for the 'status' command.
 	testCmdDesc = `The status command hits the active Synse Server host's '/test'
-	 endpoint, which returns the status of the instance. If the returned
-	 status is "ok", then Synse Server is up and reachable. Otherwise there
-	 is an error either with Synse Server or connecting to it.`
+  endpoint, which returns the status of the instance. If the returned
+  status is "ok", then Synse Server is up and reachable. Otherwise there
+  is an error either with Synse Server or connecting to it.
+
+  The 'synse status' command takes no arguments.
+
+Example:
+  synse server status
+
+Formatting:
+  The 'server status' command supports the following formatting
+  options (via the CLI global --format flag):
+    - yaml (default)
+    - json`
 )
 
 // statusCommand is the CLI command for Synse Server's "test" API route.

--- a/pkg/commands/server/transaction.go
+++ b/pkg/commands/server/transaction.go
@@ -14,9 +14,34 @@ const (
 	// transactionCmdUsage is the usage text for the 'transaction' command.
 	transactionCmdUsage = "Check the state and status of a transaction"
 
+	// transactionCmdArgsUsage is the argument usage for the 'transaction' command.
+	transactionCmdArgsUsage = "TRANSACTION_ID"
+
 	// transactionCmdDesc is the description for the 'transaction' command.
-	transactionCmdDesc = `The transaction command hits the active Synse Server host's '/transaction'
-	 endpoint, which returns the state and status of the specified transaction.`
+	transactionCmdDesc = `The transaction command hits the active Synse Server host's
+  '/transaction' endpoint, which returns the state and status of
+  the specified transaction.
+
+  Writes in Synse Server are asynchronous, so to verify that a
+  write has completed successfully, you must check the state of
+  the transaction afterwards.
+
+  The possible transaction states and statuses are:
+
+  STATUS        STATE
+  ----------    ----------
+  unknown       ok
+  pending       error
+  writing
+  done
+
+Example:
+  synse server transaction bah8volrogrg01o4sjtg
+
+Formatting:
+  The 'server transaction' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
 )
 
 // transactionCommand is the CLI command for Synse Server's "transaction" API route.
@@ -24,6 +49,7 @@ var transactionCommand = cli.Command{
 	Name:        transactionCmdName,
 	Usage:       transactionCmdUsage,
 	Description: transactionCmdDesc,
+	ArgsUsage:   transactionCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdTransaction(c))

--- a/pkg/commands/server/version.go
+++ b/pkg/commands/server/version.go
@@ -12,12 +12,21 @@ const (
 	versionCmdName = "version"
 
 	// versionCmdUsage is the usage text for the 'version' command.
-	versionCmdUsage = "Get the version of the active host"
+	versionCmdUsage = "Get the version of Synse Server"
 
 	// versionCmdDesc is the description for the 'version' command.
 	versionCmdDesc = `The version command hits the active Synse Server host's '/version'
-	 endpoint, which returns the version (full and API) of the Synse
-	 Server instance.`
+  endpoint, which returns the version (full and API) of the Synse
+  Server instance.
+
+Example:
+  synse server version
+
+Formatting:
+  The 'server version' command supports the following formatting
+  options (via the CLI global --format flag):
+    - yaml (default)
+    - json`
 )
 
 // versionCommand is the CLI command for Synse Server's "version" API route.

--- a/pkg/commands/server/write.go
+++ b/pkg/commands/server/write.go
@@ -15,13 +15,45 @@ const (
 	// writeCmdUsage is the usage text for the 'write' command.
 	writeCmdUsage = "Write to the specified device"
 
+	// writeCmdArgsUsage is the argument usage for the 'write' command.
+	writeCmdArgsUsage = "RACK BOARD DEVICE ACTION [DATA]"
+
 	// writeCmdDesc is the description for the 'write' command.
 	writeCmdDesc = `The write command hits the active Synse Server host's '/write'
-	 endpoint to write to the specified device. A Synse Server write
-	 will be passed along to the backend plugin which handles the
-	 given device to get the write information. Not all devices
-	 may support writing; device support for write is specified at
-	 the plugin level.`
+  endpoint to write to the specified device. A Synse Server write
+  will be passed along to the backend plugin which handles the
+  given device to get the write information. Not all devices
+  may support writing; support for write is determined at the
+  plugin level.
+
+  Writes are asynchronous, so issuing a write command will return
+  a transaction ID. This ID can be checked to get the state/status
+  of the write using the 'synse server transaction' command.
+
+  When writing to a device, the rack, board, and device id must be
+  specified along with the stuff to write. This 'stuff' is composed
+  of two parts -- the ACTION (e.g. the thing to change) and the
+  DATA (e.g. the value to change it to). Most devices require both
+  ACTION and DATA for writing, but some may require only an ACTION.
+
+  Below is a table listing some common actions and the requirements
+  for their data
+
+  TYPE      ACTION    DATA
+  --------  --------  -------------------
+  led       state     (on|off)
+            blink     (blink|steady)
+            color     RBG HEX string
+
+  fan       speed     integer
+
+Example:
+  synse server write rack-1 board 29d1a03e8cddfbf1cf68e14e60e5f5cc color ff00ff
+
+Formatting:
+  The 'server write' command supports the following formatting
+  options (via the CLI global --format flag):
+    - pretty (default)`
 )
 
 // writeCommand is the CLI command for Synse Server's "write" API route.
@@ -29,6 +61,7 @@ var writeCommand = cli.Command{
 	Name:        writeCmdName,
 	Usage:       writeCmdUsage,
 	Description: writeCmdDesc,
+	ArgsUsage:   writeCmdArgsUsage,
 
 	Action: func(c *cli.Context) error {
 		return utils.CmdHandler(cmdWrite(c))


### PR DESCRIPTION
This PR adds a bunch of documentation in the form of command help text. It also makes all commands define this info via the same pattern. Finally, it adds in custom templates so that all of our help output is uniform and pretty.

fixes #130 
fixes #124 
fixes #123