### PR TITLE
return synse error json in event of error

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli"
 	"github.com/vapor-ware/synse-cli/internal/test"
+	"github.com/vapor-ware/synse-cli/pkg/scheme"
 )
 
 func TestCheck1(t *testing.T) {
@@ -15,7 +16,8 @@ func TestCheck1(t *testing.T) {
 		StatusCode: 200,
 	}
 
-	e := check(&resp, err)
+	errScheme := new(scheme.Error)
+	e := check(&resp, err, errScheme)
 	test.ExpectNoError(t, e)
 }
 
@@ -25,7 +27,8 @@ func TestCheck2(t *testing.T) {
 		StatusCode: 200,
 	}
 
-	e := check(&resp, err)
+	errScheme := new(scheme.Error)
+	e := check(&resp, err, errScheme)
 	test.ExpectExitCoderError(t, e)
 }
 
@@ -35,7 +38,8 @@ func TestCheck3(t *testing.T) {
 		StatusCode: 500,
 	}
 
-	e := check(&resp, err)
+	errScheme := new(scheme.Error)
+	e := check(&resp, err, errScheme)
 	test.ExpectExitCoderError(t, e)
 }
 

--- a/pkg/scheme/error.go
+++ b/pkg/scheme/error.go
@@ -1,0 +1,10 @@
+package scheme
+
+// Error is the scheme for Synse Server error responses (e.g. 500, 404).
+type Error struct {
+	Code        int    `json:"http_code"`
+	ErrorID     int    `json:"error_id"`
+	Description string `json:"description"`
+	Timestamp   string `json:"timestamp"`
+	Context     string `json:"context"`
+}


### PR DESCRIPTION
before, when we got an error back from synse server, we got error text that just said there was an error. now, provide context for the error

```
➜ synse server read rack-1 vec eb100067acb0c054cf877759db376a34
Synse Server responded with error: 
{
  "http_code": 500,
  "error_id": 4000,
  "description": "device not found",
  "timestamp": "2018-03-09 20:30:10.982730",
  "context": "rack-1/vec/eb100067acb0c054cf877759db376a34 does not correspond with a known device."
}
```

fixes #121 


Not sure this is the best way to format the output, but we at least get useful info out with this change. Formatting can be updated later if need be.