### PR TITLE
Add back a minimal dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine
+MAINTAINER Tim Fall <tim@vapor.io>
+
+RUN apk update && apk add git
+
+RUN go get -d -v github.com/vapor-ware/synse-cli
+
+WORKDIR /go/src/github.com/vapor-ware/synse-cli
+
+RUN go get -v github.com/golang/dep/cmd/dep
+RUN dep ensure -v --vendor-only
+
+RUN cd cmd/synse/ && go build -v -o /go/bin/synse
+
+ENTRYPOINT ["synse"]
+CMD ["--help"]


### PR DESCRIPTION
Fixes #106
This won't work and can't be merged until `2.0` lands due to vendored dependedncies

Merge after merging #138 