### PR TITLE
update docs for led blink state change

### DIFF
--- a/pkg/commands/plugin/write.go
+++ b/pkg/commands/plugin/write.go
@@ -42,8 +42,7 @@ const (
 
   TYPE      ACTION    DATA
   --------  --------  -------------------
-  led       state     (on|off)
-            blink     (blink|steady)
+  led       state     (on|off|blink)
             color     RBG HEX string
 
   fan       speed     integer
@@ -55,7 +54,7 @@ Formatting:
   The 'plugin write' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+    - yaml
     - json`
 )
 

--- a/pkg/commands/server/write.go
+++ b/pkg/commands/server/write.go
@@ -41,8 +41,7 @@ const (
 
   TYPE      ACTION    DATA
   --------  --------  -------------------
-  led       state     (on|off)
-            blink     (blink|steady)
+  led       state     (on|off|blink)
             color     RBG HEX string
 
   fan       speed     integer
@@ -54,7 +53,7 @@ Formatting:
   The 'server write' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+    - yaml
     - json`
 )
 


### PR DESCRIPTION
changes to the docs on valid LED write values. the "blink" action was changed so that blink is now a value of the power state.