### PR TITLE
reduce number of parallel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: "Building"
           command: |
             cd cmd/
-            gox --output="../build/${BINARY_NAME}_{{.OS}}_{{.Arch}}" -osarch='!darwin/386'
+            gox --output="../build/${BINARY_NAME}_{{.OS}}_{{.Arch}}" -osarch='!darwin/386' -parallel=10
 
       - save_cache:
           when: on_success


### PR DESCRIPTION
fixes #158 

this wasn't an issue before, not sure why it is now, but reduced the number of parallel builds by quite a bit so it doesn't run into the memory issue