### PR TITLE
add flag to disable printing headers in pretty format

### DIFF
--- a/cmd/synse.go
+++ b/cmd/synse.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	appName    = "synse"
-	appUsage   = "Command line tool for interacting with Synse components"
+	appName  = "synse"
+	appUsage = "Command line tool for interacting with Synse components"
 )
 
 var (
@@ -83,9 +83,10 @@ func main() {
 	app.Commands = commands.Commands
 
 	app.Flags = []cli.Flag{
-		flags.DebugFlag,  // --debug, -d flag to enable debug logging output
-		flags.ConfigFlag, // --config flag to display the YAML configuration for the CLI
-		flags.FormatFlag, // --format flag to specify the output format for a command
+		flags.DebugFlag,    // --debug, -d flag to enable debug logging output
+		flags.ConfigFlag,   // --config flag to display the YAML configuration for the CLI
+		flags.FormatFlag,   // --format flag to specify the output format for a command
+		flags.NoHeaderFlag, // --no-header flag to disable printing the header in pretty format
 	}
 
 	cli.AppHelpTemplate = `

--- a/pkg/commands/server/plugins.go
+++ b/pkg/commands/server/plugins.go
@@ -26,7 +26,7 @@ Formatting:
   The 'server plugins' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+	- yaml
     - json`
 )
 

--- a/pkg/commands/server/read.go
+++ b/pkg/commands/server/read.go
@@ -37,7 +37,7 @@ Formatting:
   The 'server read' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+	- yaml
     - json`
 )
 

--- a/pkg/commands/server/scan.go
+++ b/pkg/commands/server/scan.go
@@ -53,7 +53,7 @@ Formatting:
   The 'server scan' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+	- yaml
     - json`
 )
 

--- a/pkg/commands/server/transaction.go
+++ b/pkg/commands/server/transaction.go
@@ -43,7 +43,7 @@ Formatting:
   The 'server transaction' command supports the following formatting
   options (via the CLI global --format flag):
     - pretty (default)
-		- yaml
+	- yaml
     - json`
 )
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -21,3 +21,10 @@ var FormatFlag = cli.StringFlag{
 	Value: "pretty",
 	Usage: "specify the output format for a command",
 }
+
+// NoHeaderFlag (--no-header) is a flag used to prevent printing the header
+// when pretty printing. It has no effect when the output format is not 'pretty'.
+var NoHeaderFlag = cli.BoolFlag{
+	Name:  "no-header",
+	Usage: "do not print the header when pretty-printing output",
+}

--- a/pkg/formatters/format.go
+++ b/pkg/formatters/format.go
@@ -33,10 +33,14 @@ type Formatter struct {
 	Output  io.Writer
 	Context *cli.Context
 
-	// Formatter state for pretty printing
+	// Handler for pretty printing
 	prettyHandler func(interface{}) (interface{}, error)
-	header        interface{}
-	data          []interface{}
+
+	// Header for pretty output
+	header interface{}
+
+	// Data (rows) for pretty output
+	data []interface{}
 }
 
 // templateFns are custom functions that we can call in templates.
@@ -150,7 +154,9 @@ func (f *Formatter) writePretty() error {
 		return err
 	}
 
-	if f.header != nil {
+	noHeader := f.Context.GlobalBool("no-header")
+
+	if f.header != nil && !noHeader {
 		err = tmpl.Execute(w, f.header)
 		if err != nil {
 			return err


### PR DESCRIPTION
Without the `--no-header` flag:
```console
$ ./build/synse server scan
RACK      BOARD     DEVICE                             INFO                         TYPE
rack-1    vec       29d1a03e8cddfbf1cf68e14e60e5f5cc   Synse Airflow Sensor         airflow
rack-1    vec       329a91c6781ce92370a3c38ba9bf35b2   Synse Temperature Sensor 4   temperature
rack-1    vec       5b2ce651ad91715c96ec71f4096c5d0e   Synse Pressure Sensor 2      pressure
rack-1    vec       83cc1efe7e596e4ab6769e0c6e3edf88   Synse Temperature Sensor 2   temperature
rack-1    vec       bbadeee4d96ca38ffbcaabb3d8837526   Synse Humidity Sensor        humidity
rack-1    vec       d29e0bd113a484dc48fd55bd3abad6bb   Synse backup LED             led
rack-1    vec       db1e5deb43d9d0af6d80885e74362913   Synse Temperature Sensor 3   temperature
rack-1    vec       eb100067acb0c054cf877759db376b03   Synse Temperature Sensor 1   temperature
rack-1    vec       eb9a56f95b5bd6d9b51996ccd0f2329c   Synse Fan                    fan
rack-1    vec       f3dd2a56b588f181c5c782f45467b214   Synse Pressure Sensor 1      pressure
rack-1    vec       f52d29fecf05a195af13f14c7306cfed   Synse LED                    led
rack-1    vec       f97f284037b04badb6bb7aacd9654a4e   Synse Temperature Sensor 5   temperature
```

With the `--no-header` flag
```console
$ ./build/synse --no-header server scan
rack-1    vec       29d1a03e8cddfbf1cf68e14e60e5f5cc   Synse Airflow Sensor         airflow
rack-1    vec       329a91c6781ce92370a3c38ba9bf35b2   Synse Temperature Sensor 4   temperature
rack-1    vec       5b2ce651ad91715c96ec71f4096c5d0e   Synse Pressure Sensor 2      pressure
rack-1    vec       83cc1efe7e596e4ab6769e0c6e3edf88   Synse Temperature Sensor 2   temperature
rack-1    vec       bbadeee4d96ca38ffbcaabb3d8837526   Synse Humidity Sensor        humidity
rack-1    vec       d29e0bd113a484dc48fd55bd3abad6bb   Synse backup LED             led
rack-1    vec       db1e5deb43d9d0af6d80885e74362913   Synse Temperature Sensor 3   temperature
rack-1    vec       eb100067acb0c054cf877759db376b03   Synse Temperature Sensor 1   temperature
rack-1    vec       eb9a56f95b5bd6d9b51996ccd0f2329c   Synse Fan                    fan
rack-1    vec       f3dd2a56b588f181c5c782f45467b214   Synse Pressure Sensor 1      pressure
rack-1    vec       f52d29fecf05a195af13f14c7306cfed   Synse LED                    led
rack-1    vec       f97f284037b04badb6bb7aacd9654a4e   Synse Temperature Sensor 5   temperature
```
