### PR TITLE
Update plugin subcommands due to gRPC 1.0 changes

### DIFF
--- a/pkg/commands/plugin/read.go
+++ b/pkg/commands/plugin/read.go
@@ -79,7 +79,10 @@ func cmdRead(c *cli.Context) error { // nolint: gocyclo
 			Type:      read.GetType(),
 			Info:      read.GetInfo(),
 			Value:     getValue(read),
-			Unit:      scheme.OutputUnit{read.Unit.Name, read.Unit.Symbol},
+			Unit: scheme.OutputUnit{
+				Name:   read.Unit.Name,
+				Symbol: read.Unit.Symbol,
+			},
 		})
 	}
 
@@ -115,7 +118,9 @@ func getValue(value *synse.Reading) interface{} { // nolint: gocyclo
 	case *synse.Reading_Uint64Value:
 		return value.GetUint64Value()
 	default:
-		// FIXME: Should we return nil here?
+		// FIXME: Should we return nil here? Because if it's nil, the formatter
+		// will output a weird string. Also, need to come up with a strategy to
+		// handle this nil error because there is none at the moment.
 		return nil
 	}
 }

--- a/pkg/commands/plugin/read_test.go
+++ b/pkg/commands/plugin/read_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/vapor-ware/synse-cli/internal/test"
 	"github.com/vapor-ware/synse-cli/pkg/client"
+	"github.com/vapor-ware/synse-server-grpc/go"
 )
 
 // TestReadCommandError tests the 'read' command when the plugin
@@ -99,4 +101,90 @@ func TestReadCommandError5(t *testing.T) {
 
 	assert.Assert(t, golden.String(app.ErrBuffer.String(), "read.error.extra_args.golden"))
 	test.ExpectExitCoderError(t, err)
+}
+
+// TestGetValue tests the getValue function.
+func TestGetValue(t *testing.T) {
+	tests := []struct {
+		in  *synse.Reading
+		out interface{}
+	}{
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_StringValue{StringValue: "test"},
+			},
+			out: "test",
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_BoolValue{BoolValue: true},
+			},
+			out: true,
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Float32Value{Float32Value: 0.6046603},
+			},
+			out: float32(0.6046603),
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Float64Value{Float64Value: 0.6046602879796196},
+			},
+			out: float64(0.6046602879796196),
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Int32Value{Int32Value: 1298498081},
+			},
+			out: int32(1298498081),
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Int64Value{Int64Value: 5577006791947779410},
+			},
+			out: int64(5577006791947779410),
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Uint32Value{Uint32Value: 2596996162},
+			},
+			out: uint32(2596996162),
+		},
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_Uint64Value{Uint64Value: 5577006791947779410},
+			},
+			out: uint64(5577006791947779410),
+		},
+	}
+
+	for _, test := range tests {
+		r := getValue(test.in)
+		if r != test.out {
+			t.Errorf("getValue(%v) => %v Out:%v", test.in, r, test.out)
+		}
+	}
+}
+
+// TestGetValueBytes tests getValue function where input is a slice of byte.
+func TestGetValueBytes(t *testing.T) {
+	tests := []struct {
+		in  *synse.Reading
+		out []byte
+	}{
+		{
+			in: &synse.Reading{
+				Value: &synse.Reading_BytesValue{BytesValue: []byte("foo")},
+			},
+			out: []byte("foo"),
+		},
+	}
+
+	for _, test := range tests {
+		r := getValue(test.in).([]byte)
+		if !bytes.Equal(r, test.out) {
+			t.Errorf("getValue(%v) => %v Out:%v", test.in, r, test.out)
+		}
+	}
 }

--- a/pkg/commands/plugin/write.go
+++ b/pkg/commands/plugin/write.go
@@ -98,7 +98,7 @@ func cmdWrite(c *cli.Context) error { // nolint: gocyclo
 		return err
 	}
 
-	t := make([]scheme.WriteTransaction, len(transactions.Transactions))
+	t := make([]scheme.WriteTransaction, 0)
 	for id, ctx := range transactions.Transactions {
 		t = append(t, scheme.WriteTransaction{
 			Transaction: id,

--- a/pkg/commands/server/write.go
+++ b/pkg/commands/server/write.go
@@ -83,9 +83,9 @@ func cmdWrite(c *cli.Context) error {
 	board := c.Args().Get(1)
 	device := c.Args().Get(2)
 	action := c.Args().Get(3)
-	raw := c.Args().Get(4)
+	data := c.Args().Get(4)
 
-	write, err := client.Client.Write(rack, board, device, action, raw)
+	write, err := client.Client.Write(rack, board, device, action, data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR updates existing functionalities of plugin subcommands (`synse plugin COMMAND`) over gRPC 1.0 changes. It is a continuation of #177 to finish off #172.