### PR TITLE
Refactor pretty output scheme of `capabilities` and `devices`

### DIFF
--- a/pkg/formatters/capabilities.go
+++ b/pkg/formatters/capabilities.go
@@ -17,19 +17,6 @@ const (
 	prettyPluginCapabilities = "{{.Kind}}\t{{.Outputs}}\t\n"
 )
 
-// serverCapabilityFormat is the format for `server capabilities` command.
-type serverCapabilityFormat struct {
-	Plugin  string `json:"plugin"`
-	Kind    string `json:"kind"`
-	Outputs string `json:"outputs"`
-}
-
-// pluginCapabilityFormat is the format for `plugin capabilities` command.
-type pluginCapabilityFormat struct {
-	Kind    string
-	Outputs string
-}
-
 // newServerCapabilitiesFormat is the handler for `server capabilities` commands that is
 // used by the Formatter to add new capabilities data to the format context.
 func newServerCapabilitiesFormat(data interface{}) (interface{}, error) {
@@ -41,7 +28,7 @@ func newServerCapabilitiesFormat(data interface{}) (interface{}, error) {
 	var out []interface{}
 	for _, c := range capabilities {
 		for _, d := range c.Devices {
-			out = append(out, &serverCapabilityFormat{
+			out = append(out, &scheme.ServerCapabilityOutput{
 				Plugin:  c.Plugin,
 				Kind:    d.Kind,
 				Outputs: fmt.Sprint(strings.Join(d.Outputs, ", ")),
@@ -59,7 +46,7 @@ func newPluginCapabilitiesFormat(data interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("formatter data %T not of type *DeviceCapability", capability)
 	}
 
-	return &pluginCapabilityFormat{
+	return &scheme.PluginCapabilityOutput{
 		Kind:    capability.Kind,
 		Outputs: fmt.Sprint(strings.Join(capability.Outputs, ", ")),
 	}, nil
@@ -70,7 +57,7 @@ func newPluginCapabilitiesFormat(data interface{}) (interface{}, error) {
 func NewServerCapabilitiesFormatter(c *cli.Context) *Formatter {
 	f := NewFormatter(c, newServerCapabilitiesFormat)
 	f.Template = prettyServerCapabilities
-	f.Decoder = &serverCapabilityFormat{}
+	f.Decoder = &scheme.ServerCapabilityOutput{}
 
 	return f
 }
@@ -80,7 +67,7 @@ func NewServerCapabilitiesFormatter(c *cli.Context) *Formatter {
 func NewPluginCapabilitiesFormatter(c *cli.Context) *Formatter {
 	f := NewFormatter(c, newPluginCapabilitiesFormat)
 	f.Template = prettyPluginCapabilities
-	f.Decoder = &pluginCapabilityFormat{}
+	f.Decoder = &scheme.PluginCapabilityOutput{}
 
 	return f
 }

--- a/pkg/formatters/scan.go
+++ b/pkg/formatters/scan.go
@@ -16,16 +16,6 @@ const (
 	prettyDevices = "{{.ID}}\t{{.Kind}}\t{{.Plugin}}\t{{.Info}}\t{{.Rack}}\t{{.Board}}\n"
 )
 
-// devicesFormat collects the data that will be parsed into the output template.
-type devicesFormat struct {
-	ID     string
-	Kind   string
-	Plugin string
-	Info   string
-	Rack   string
-	Board  string
-}
-
 // newScanFormat is the handler for scan commands that is used by the
 // Formatter to add new scan data to the format context.
 func newScanFormat(data interface{}) (interface{}, error) {
@@ -43,7 +33,7 @@ func newDevicesFormat(data interface{}) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("formatter data %T not of type *Device", device)
 	}
-	return &devicesFormat{
+	return &scheme.DevicesOutput{
 		ID:     device.Uid,
 		Kind:   device.Kind,
 		Plugin: device.Plugin,

--- a/pkg/scheme/capabilities.go
+++ b/pkg/scheme/capabilities.go
@@ -11,3 +11,16 @@ type CapabilityDevice struct {
 	Kind    string   `json:"kind" yaml:"kind"`
 	Outputs []string `json:"outputs" yaml:"outputs"`
 }
+
+// ServerCapabilityOutput is the scheme for `server capabilities` pretty output.
+type ServerCapabilityOutput struct {
+	Plugin  string `json:"plugin"`
+	Kind    string `json:"kind"`
+	Outputs string `json:"outputs"`
+}
+
+// PluginCapabilityOutput is the scheme for `plugin capabilities` pretty output.
+type PluginCapabilityOutput struct {
+	Kind    string
+	Outputs string
+}

--- a/pkg/scheme/devices.go
+++ b/pkg/scheme/devices.go
@@ -1,6 +1,6 @@
 package scheme
 
-// DevicesOutput dines the scheme for the data output by a "plugin devices" command.
+// DevicesOutput is the scheme for `plugin devices` pretty output.
 type DevicesOutput struct {
 	ID     string
 	Kind   string


### PR DESCRIPTION
This PR basically moves the scheme output of `capabilities` and `devices` to the scheme folder for consistency.