### PR TITLE
Validate read input before filtering

### DIFF
--- a/pkg/commands/server/read_test.go
+++ b/pkg/commands/server/read_test.go
@@ -130,6 +130,14 @@ func TestReadCommandRequestError(t *testing.T) {
 		},
 	)
 	mux.HandleFunc(
+		"/synse/2.0/info/rack-1/board-1/device-1",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+			test.Fprint(t, w, infoRespErr)
+		},
+	)
+	mux.HandleFunc(
 		"/synse/2.0/read/rack-1/board-1/device-1",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -252,6 +260,13 @@ func TestReadCommandRequestSuccessPretty(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			test.Fprint(t, w, scanRespOK)
+		},
+	)
+	mux.HandleFunc(
+		"/synse/2.0/info/rack-1/board-1/device-1",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			test.Fprint(t, w, infoDeviceRespOK)
 		},
 	)
 	mux.HandleFunc(


### PR DESCRIPTION
This PR attempts to fix #179 and #187's comment. The idea is, for a `read` command that eventually returns a `nil` response for the formatter, which returns *nothing* to user, we want to validate it first. By checking the returned error from Synse Server via `info` endpoint, we make sure that `nil` is never the case. User will either receive a good response or an error.

If this PR is approved, I will go ahead and fix all the remaining test cases for read and open a seperate PR for that.