### PR TITLE
remove dist folder, tidy dependencies

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -38,6 +38,7 @@ pipeline {
         stage('Snapshot Build') {
           steps {
             container('golang') {
+              sh 'rm -rf dist'
               sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
             }
           }
@@ -54,6 +55,7 @@ pipeline {
       }
       steps {
         container('golang') {
+          sh 'rm -rf dist'
           withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
             sh 'goreleaser release --debug --rm-dist'
           }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 BIN_NAME    := synse
-BIN_VERSION := 3.0.0-alpha.1
+BIN_VERSION := 3.0.0-alpha.2
 
 GIT_COMMIT  ?= $(shell git rev-parse --short HEAD 2> /dev/null || true)
 GIT_TAG     ?= $(shell git describe --tags 2> /dev/null || true)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5 // indirect
 	golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8 // indirect
 	google.golang.org/grpc v1.20.1
 	gopkg.in/resty.v1 v1.12.0 // indirect


### PR DESCRIPTION
This PR:
- removes the dist folder from goreleaser in CI
- tidies go.mod file

The previous alpha tag release [failed CI](https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fsynse-cli/detail/3.0.0-alpha.1/1/pipeline), apparently for these reasons. I'm not 100% sure why go.mod was in a dirty state, but I think this might fix it.