### PR TITLE
deps: update SDK dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ LDFLAGS := -w \
 build:  ## Build the executable binary
 	CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "${LDFLAGS}" -o ${BIN_NAME} cmd/synse.go
 
+.PHONY: build-linux
+build-linux:  ## Build the executable binary for linux
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "${LDFLAGS}" -o ${BIN_NAME} cmd/synse.go
+
 .PHONY: clean
 clean:  ## Remove temporary files and build artifacts
 	go clean -v

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1
 	github.com/vapor-ware/synse-client-go v0.0.0-20200327150857-a8726f53089e
-	github.com/vapor-ware/synse-server-grpc v0.0.2-0.20200327135045-e8fab4d340ea
+	github.com/vapor-ware/synse-server-grpc v0.0.2-0.20210119154353-cd9e4e05bb31
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20200326112834-f447254575fd // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vapor-ware/synse-client-go v0.0.0-20200327150857-a8726f53089e h1:odhrv3eNaXPu2bEPKK/9kQDmiVXGQTCXetLjlOLW3tU=
 github.com/vapor-ware/synse-client-go v0.0.0-20200327150857-a8726f53089e/go.mod h1:aCTBPYi3NRdSSCEbiIshrHp76JnmqR0vdqn0JIw63I8=
-github.com/vapor-ware/synse-server-grpc v0.0.2-0.20200327135045-e8fab4d340ea h1:3IenfSpSRcMEmdMMixiKZ2S16X0YvPFNEUvESvHwyAc=
-github.com/vapor-ware/synse-server-grpc v0.0.2-0.20200327135045-e8fab4d340ea/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
+github.com/vapor-ware/synse-server-grpc v0.0.2-0.20210119154353-cd9e4e05bb31 h1:frnpaZ5Ys3NjhcWydKow9NCI093bR59y9GExF4qzR2E=
+github.com/vapor-ware/synse-server-grpc v0.0.2-0.20210119154353-cd9e4e05bb31/go.mod h1:66oRQ1KV/ZevAiiXbSUjRbx/h91xG/ArE/V39Jh872I=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
This PR:
- picks up the latest SDK update, which allows for device_info in the reading model.
- the cli does not print out the info in the tabular view -- if thats desired, it can be added as a separate issue
- the info will be present when printing out in json/yaml format, assuming the plugin/synse-server are of a version which supports the grpc message/sdk update
- adds an explicit local build target for linux