### PR TITLE
VIO-1911 Bump logic to latest goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,6 @@ before:
 builds:
   -
     main: ./cmd/synse.go
-    binary: synse
     env:
       - CGO_ENABLED=0
     ldflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ archives:
   - format: tar.gz
 brews:
   -
-    github:
+    tap:
       owner: vapor-ware
       name: homebrew-formula
     commit_author:

--- a/.jenkins
+++ b/.jenkins
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@1.19.7', retriever: modernSCM([
+library identifier: 'vapor@1.20.1', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',


### PR DESCRIPTION
- VIO-1911 Remove yaml not compatible with latest goreleaser
- VIO-1911 Build with latest goreleaser logic
