### PR TITLE
Fix CLI not persisting config changes in HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synse CLI
 
-[![Build Status](https://build.vio.sh/buildStatus/icon?job=vapor-ware/synse-cli/master)](https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fsynse-cli/activity)
+[![Build Status](https://github.com/vapor-ware/synse-cli/workflows/build/badge.svg)](https://github.com/vapor-ware/synse-cli/actions)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fvapor-ware%2Fsynse-cli.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fvapor-ware%2Fsynse-cli?ref=badge_shield)
 [![Go ReportCard](https://goreportcard.com/badge/github.com/vapor-ware/synse-cli)](https://goreportcard.com/report/github.com/vapor-ware/synse-cli)
 

--- a/go.mod
+++ b/go.mod
@@ -22,11 +22,11 @@ require (
 )
 
 require (
-	github.com/creasty/defaults v1.3.0 // indirect
+	github.com/creasty/defaults v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,9 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creasty/defaults v1.3.0 h1:uG+RAxYbJgOPCOdKEcec9ZJXeva7Y6mj/8egdzwmLtw=
 github.com/creasty/defaults v1.3.0/go.mod h1:CIEEvs7oIVZm30R8VxtFJs+4k201gReYyuYHJxZc68I=
+github.com/creasty/defaults v1.6.0 h1:ltuE9cfphUtlrBeomuu8PEyISTXnxqkBIoQfXgv7BSc=
+github.com/creasty/defaults v1.6.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -138,8 +139,9 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gookit/color v1.5.1 h1:Vjg2VEcdHpwq+oY63s/ksHrgJYCTo0bwWvmmYWdE9fQ=
 github.com/gookit/color v1.5.1/go.mod h1:wZFzea4X8qN6vHOSP2apMb4/+w/orMznEzYsIHPaqKM=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
 github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -317,7 +319,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 
@@ -85,11 +86,20 @@ func Load() error {
 // Persist saves the CLI configuration to disk, writing back the
 // in-memory config to the configuration YAML file.
 func Persist() error {
-	var configPath = filepath.Join(".", configFile)
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	var configPath = filepath.Join(wd, configFile)
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
 		log.Debug("persisting cli config to HOME directory")
-		configPath = filepath.Join(os.Getenv("HOME"), configFile)
-	} else {
+		configPath = filepath.Join(home, configFile)
+	} else if err != nil {
+		log.Debug(fmt.Sprintf("stat cli config: %v", err))
 		return err
 	}
 

--- a/pkg/utils/http_test.go
+++ b/pkg/utils/http_test.go
@@ -30,13 +30,29 @@ func TestNewSynseHTTPClient_noContext(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestNewSynseHTTPClient_noCurrentCtx(t *testing.T) {
+func TestNewSynseHTTPClient_invalidURI(t *testing.T) {
 	defer config.Purge()
 	err := config.AddContext(&config.ContextRecord{
 		Name: "testctx",
 		Type: "server",
 		Context: config.Context{
 			Address: "foo",
+		},
+	})
+	assert.NoError(t, err)
+
+	client, err := NewSynseHTTPClient("", "")
+	assert.Nil(t, client)
+	assert.Error(t, err)
+}
+
+func TestNewSynseHTTPClient_noCurrentCtx(t *testing.T) {
+	defer config.Purge()
+	err := config.AddContext(&config.ContextRecord{
+		Name: "testctx",
+		Type: "server",
+		Context: config.Context{
+			Address: "localhost:5000",
 		},
 	})
 	assert.NoError(t, err)
@@ -55,7 +71,7 @@ func TestNewSynseHTTPClient_namedContext(t *testing.T) {
 		Name: "testctx",
 		Type: "server",
 		Context: config.Context{
-			Address: "foo",
+			Address: "localhost:5000",
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
Previously if running the cli from the home dir without having `$HOME`, the CLI would return a nil err. This PR ensures it would actually persist the config.

Closes #239 

Signed-off-by: Sam Foo <sam.foo@vapor.io>