### PR TITLE
Context warning

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,7 +148,7 @@ func (c *Config) AddContext(ctx *ContextRecord) error {
 			break
 		} else if context.Context.Address == ctx.Context.Address {
 			if context.Type == ctx.Type {
-				log.Warnf("existing context '%s' with type '%s' already available on the address '%s'", ctx.Name, ctx.Type, ctx.Context.Address)
+				log.Warnf("existing context '%s' with type '%s' already available on the address '%s'", context.Name, context.Type, context.Context.Address)
 			}
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,9 +18,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
@@ -145,7 +146,12 @@ func (c *Config) AddContext(ctx *ContextRecord) error {
 		if context.Name == ctx.Name {
 			contextExists = true
 			break
+		} else if context.Context.Address == ctx.Context.Address {
+			if context.Type == ctx.Type {
+				log.Warnf("existing context '%s' with type '%s' already available on the address '%s'", ctx.Name, ctx.Type, ctx.Context.Address)
+			}
 		}
+
 	}
 	if contextExists {
 		return fmt.Errorf("cannot add context '%s': name already exists", ctx.Name)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,7 +148,7 @@ func (c *Config) AddContext(ctx *ContextRecord) error {
 			break
 		} else if context.Context.Address == ctx.Context.Address {
 			if context.Type == ctx.Type {
-				log.Warnf("existing context '%s' with type '%s' already available on the address '%s'", context.Name, context.Type, context.Context.Address)
+				log.Warnf("context '%s' with type '%s' already available on the address '%s'", context.Name, context.Type, context.Context.Address)
 			}
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,10 +146,8 @@ func (c *Config) AddContext(ctx *ContextRecord) error {
 		if context.Name == ctx.Name {
 			contextExists = true
 			break
-		} else if context.Context.Address == ctx.Context.Address {
-			if context.Type == ctx.Type {
-				log.Warnf("context '%s' with type '%s' already available on the address '%s'", context.Name, context.Type, context.Context.Address)
-			}
+		} else if (context.Context.Address == ctx.Context.Address) && (context.Type == ctx.Type) {
+			log.Warnf("context '%s' with type '%s' already available on the address '%s'", context.Name, context.Type, context.Context.Address)
 		}
 
 	}


### PR DESCRIPTION
This PR:

is providing better response while adding context. This will throw warning while adding different named context with same type and same address value.