### PR TITLE
feat: add unset context command

### DIFF
--- a/pkg/cmd/context/root.go
+++ b/pkg/cmd/context/root.go
@@ -59,6 +59,7 @@ func New() *cobra.Command {
 		cmdList,
 		cmdRemove,
 		cmdSet,
+		cmdUnset,
 	)
 
 	return cmd

--- a/pkg/cmd/context/testdata/unset.extra-args.golden
+++ b/pkg/cmd/context/testdata/unset.extra-args.golden
@@ -1,0 +1,7 @@
+Error: accepts 1 arg(s), received 2
+Usage:
+  unset CONTEXT_NAME [flags]
+
+Flags:
+  -h, --help   help for unset
+

--- a/pkg/cmd/context/testdata/unset.nonexisting.golden
+++ b/pkg/cmd/context/testdata/unset.nonexisting.golden
@@ -1,0 +1,1 @@
+Error: cannot unset 'foo' from current context: no such context

--- a/pkg/cmd/context/unset.go
+++ b/pkg/cmd/context/unset.go
@@ -1,0 +1,48 @@
+// Synse CLI
+// Copyright (c) 2023 Vapor IO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package context
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vapor-ware/synse-cli/pkg/config"
+	"github.com/vapor-ware/synse-cli/pkg/utils"
+	"github.com/vapor-ware/synse-cli/pkg/utils/exit"
+)
+
+var cmdUnset = &cobra.Command{
+	Use:   "unset CONTEXT_NAME",
+	Short: "Unset the current context",
+	Long: utils.Doc(`
+		Unset the current active context for the CLI.
+	`),
+	SuggestFor: []string{
+		"change",
+	},
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		exit.FromCmd(cmd).Err(unsetContext(args[0]))
+	},
+}
+
+func unsetContext(name string) error {
+	log.WithFields(log.Fields{
+		"name": name,
+	}).Debug("unsetting current context")
+
+	return config.UnsetCurrentContext(name)
+}

--- a/pkg/cmd/context/unset_test.go
+++ b/pkg/cmd/context/unset_test.go
@@ -1,0 +1,100 @@
+// Synse CLI
+// Copyright (c) 2023 Vapor IO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-cli/internal/test"
+	"github.com/vapor-ware/synse-cli/pkg/config"
+)
+
+func TestCmdUnset_extraArgs(t *testing.T) {
+	defer func() {
+		config.Purge()
+		resetFlags()
+	}()
+
+	result := test.Cmd(cmdUnset).Args(
+		"foo",
+		"bar",
+	).Run(t)
+	result.AssertErr()
+	result.AssertGolden("unset.extra-args.golden")
+
+	assert.Len(t, config.GetContexts(), 0)
+	assert.Len(t, config.GetCurrentContext(), 0)
+}
+
+func TestCmdUnset_existingCtx(t *testing.T) {
+	defer func() {
+		config.Purge()
+		resetFlags()
+	}()
+
+	assert.NoError(t, config.AddContext(&config.ContextRecord{
+		Name: "test-ctx",
+		Type: "server",
+		Context: config.Context{
+			Address:    "0.0.0.0",
+			ClientCert: "/tmp/test/dir",
+		},
+	}))
+	assert.NoError(t, config.SetCurrentContext("test-ctx"))
+
+	assert.Len(t, config.GetContexts(), 1)
+	assert.Len(t, config.GetCurrentContext(), 1)
+
+	result := test.Cmd(cmdUnset).Args(
+		"test-ctx",
+	).Run(t)
+	result.AssertNoErr()
+	result.AssertGolden("empty.golden")
+
+	assert.Len(t, config.GetContexts(), 1)
+	assert.Len(t, config.GetCurrentContext(), 0)
+}
+
+func TestCmdUnset_nonexistingCtx(t *testing.T) {
+	defer func() {
+		config.Purge()
+		resetFlags()
+	}()
+
+	assert.NoError(t, config.AddContext(&config.ContextRecord{
+		Name: "test-ctx",
+		Type: "server",
+		Context: config.Context{
+			Address:    "0.0.0.0",
+			ClientCert: "/tmp/test/dir",
+		},
+	}))
+
+	assert.Len(t, config.GetContexts(), 1)
+	assert.Len(t, config.GetCurrentContext(), 0)
+
+	result := test.Cmd(cmdUnset).Args(
+		"foo",
+	).Run(t)
+	result.AssertNoErr()
+	result.AssertExited()
+	result.AssertGolden("unset.nonexisting.golden")
+
+	assert.Len(t, config.GetContexts(), 1)
+	assert.Len(t, config.GetCurrentContext(), 0)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,9 +18,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
@@ -246,6 +247,32 @@ func (c *Config) SetCurrentContext(name string) error {
 // SetCurrentContext sets the current context for the default configuration.
 func SetCurrentContext(name string) error {
 	return config.SetCurrentContext(name)
+}
+
+// UnsetCurrentContext unsets the named context from the current active context. If
+// the given name does not correspond to a ContextRecord, an error is returned.
+func (c *Config) UnsetCurrentContext(name string) error {
+	var context *ContextRecord
+	for _, ctx := range c.Contexts {
+		if ctx.Name == name {
+			context = &ctx
+			break
+		}
+	}
+	if context == nil {
+		return fmt.Errorf("cannot unset '%s' from current context: no such context", name)
+	}
+
+	if c.CurrentContext[context.Type] == context.Name {
+		delete(c.CurrentContext, context.Type)
+	}
+	log.WithField("context", name).Debug("unset current context")
+	return nil
+}
+
+// UnsetCurrentContext unsets the current context from the default configuration.
+func UnsetCurrentContext(name string) error {
+	return config.UnsetCurrentContext(name)
 }
 
 // GetCurrentContext gets the ContextRecords for the current context, if set.


### PR DESCRIPTION
This PR:

- Adds a new `unset` command to unset a current active context

Question - should an error be raised if the current context is not the one provided?

[VIO-3177]

[VIO-3177]: https://vaporio.atlassian.net/browse/VIO-3177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ