### PR TITLE
Removed deprecated use of tap: for repository:

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ archives:
   - format: tar.gz
 brews:
   -
-    tap:
+    repository:
       owner: vapor-ware
       name: homebrew-formula
     commit_author:


### PR DESCRIPTION
Changes for synse-cli release v3.0.1.

### TESTING

1) Check release.
```
[sdicki@Phoenix] ~/Development/git/vapor-io/synse-cli$ goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking configuration...
  • DEPRECATED:  brews.tap  should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

2) Change `tap:` to `repository:` in .goreleaser.yml

3) Re-check release.
```
[sdicki@Phoenix] ~/Development/git/vapor-io/synse-cli$ goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking configuration...
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```
